### PR TITLE
Add EVAA, Factorial and a "pool" tag

### DIFF
--- a/assets/dex/dedust.json
+++ b/assets/dex/dedust.json
@@ -11,9 +11,10 @@
         {
             "address": "EQDa4VOnTYlLvDJ0gZjNYm5PXfSmmtL6Vs6A_CZEtXCNICq_",
             "source": "",
-            "comment": "DeDust Vault",
+            "comment": "DeDust Vault, TON",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"
@@ -21,9 +22,10 @@
         {
             "address": "EQAYqo4u7VF0fa4DPAebk4g9lBytj2VFny7pzXR0trjtXQaO",
             "source": "",
-            "comment": "DeDust Vault",
+            "comment": "DeDust Vault, USDT",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"
@@ -31,9 +33,10 @@
         {
             "address": "EQA11HErC5dJpSHVa9Sk5xGLRCn1It6t-XbsuNjsxMW1qCxS",
             "source": "",
-            "comment": "DeDust Vault",
+            "comment": "DeDust Vault, TELEMON",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"
@@ -41,9 +44,10 @@
         {
             "address": "EQBmcjRa8-KweRMrcmyf0KTnlirhaE4RRNYYdEY_XZiIlmg9",
             "source": "",
-            "comment": "DeDust Vault",
+            "comment": "DeDust Vault, Kat Knight",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-21T00:00:01Z"
@@ -51,9 +55,10 @@
         {
             "address": "EQDZ4yPwODeNi22_Qjqx9HKkM5SvBX4qHBT0l19VPqBuzm0u",
             "source": "",
-            "comment": "DeDust Vault | $NotPixel",
+            "comment": "DeDust Vault, $NotPixel",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-27T00:00:01Z"

--- a/assets/dex/stormtrade.json
+++ b/assets/dex/stormtrade.json
@@ -23,7 +23,8 @@
             "source": "",
             "comment": "TON vault",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-01-14T00:00:01Z"
@@ -33,7 +34,8 @@
             "source": "",
             "comment": "NOT vault",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-01-14T00:00:01Z"
@@ -43,10 +45,21 @@
             "source": "",
             "comment": "USDT vault",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-01-14T00:00:01Z"
+        },
+        {
+            "address": "EQDaC-uD4Q0GkTnG9lXqPb5HKgyUhlzcQVJOHJDnDyVNUdik",
+            "source": "",
+            "comment": "stormstaking.ton | Claim Staking rewards",
+            "tags": [
+                "defi"
+            ],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-01-29T00:00:01Z"
         }
     ]
 }

--- a/assets/gaming/bums.json
+++ b/assets/gaming/bums.json
@@ -79,6 +79,14 @@
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-15T00:00:01Z"
+        },
+        {
+            "address": "EQAo5cI-jQuIC2o_3w68l4F7d8PVeHbWhXbcmTpGHHkc08Ab",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-02-01T00:00:01Z"
         }
     ]
 }

--- a/assets/lending/coffin.json
+++ b/assets/lending/coffin.json
@@ -13,7 +13,8 @@
             "source": "",
             "comment": "Coffin Pool",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-22T00:00:01Z"

--- a/assets/lending/evaa.json
+++ b/assets/lending/evaa.json
@@ -37,6 +37,16 @@
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"
+        },
+        {
+            "address": "EQD9GyPsGeKvBAzbMac7_uFkwsKVJeeaIWX3rhpfAyia-QmN",
+            "source": "",
+            "comment": "Evaa Rewards",
+            "tags": [
+                "defi"
+            ],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-01-28T00:00:01Z"
         }
     ]
 }

--- a/assets/lending/evaa.json
+++ b/assets/lending/evaa.json
@@ -31,7 +31,7 @@
         {
             "address": "EQANURVS3fhBO9bivig34iyJQi97FhMbpivo1aUEAS2GYSu-",
             "source": "",
-            "comment": "Evaa LP Mainnet",
+            "comment": "Evaa Alts Mainnet",
             "tags": [
                 "defi"
             ],

--- a/assets/lending/evaa.json
+++ b/assets/lending/evaa.json
@@ -13,7 +13,8 @@
             "source": "",
             "comment": "Evaa Master Mainnet",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"
@@ -23,7 +24,8 @@
             "source": "",
             "comment": "Evaa LP Mainnet",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"
@@ -33,7 +35,8 @@
             "source": "",
             "comment": "Evaa Alts Mainnet",
             "tags": [
-                "defi"
+                "defi",
+                "pool"
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"

--- a/assets/lending/factorial.json
+++ b/assets/lending/factorial.json
@@ -1,0 +1,23 @@
+{
+    "metadata": {
+        "label": "factorial",
+        "category": "lending",
+        "subcategory": "",
+        "website": "https://factorial.finance",
+        "description": "",
+        "organization": "factorial"
+    },
+    "addresses": [
+        {
+            "address": "EQCrEHHG4Ff8TD3PzuH5tFSwHBD3zxeXaosz48jGLebwiiNx",
+            "source": "",
+            "comment": "Basic Pool",
+            "tags": [
+                "defi",
+                "pool"
+            ],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-01-31T00:00:01Z"
+        }
+    ]
+}

--- a/assets/scammer/scammer.json
+++ b/assets/scammer/scammer.json
@@ -51,6 +51,17 @@
             ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:00Z"
+        },
+        {
+            "address": "EQArgvRqn3f0CSRg3yREnyfuXpIFG2xb3iE5iaPbfPVuy40A",
+            "source": "",
+            "comment": "mimic for legit CEX addresses with first and last symbols of their address",
+            "tags": [
+                "scammer",
+                "suspicious"
+            ],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-01-28T00:00:00Z"
         }
     ]
 }

--- a/tags.json
+++ b/tags.json
@@ -62,5 +62,9 @@
     {
         "name": "telegram-stars-rewards-withdrawal",
         "description": "Telegram Stars rewards withdrawal address (from Fragment)"
+    },
+    {
+        "name": "pool",
+        "description": "Liquidity pool"
     }
 ]


### PR DESCRIPTION
After merging, we need to update dune.com/ton_foundation/evaa dashboard to use only EVAA addresses with "pool" tag. Otherwise the reward payouts will be treated as a withdraws from the protocol which will add errors in the TVL calculation assumptions we have.