### PR TITLE
Add getgems seller contract label

### DIFF
--- a/assets/merchant/getgems.json
+++ b/assets/merchant/getgems.json
@@ -47,6 +47,14 @@
             "tags": [],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-03-03T00:00:01Z"
+        },
+        {
+            "address": "EQAKyOQOka8VYM-cmziFD_dsNuOY_KXUol7E3CsKJp4-ZFgm",
+            "source": "",
+            "comment": "Getgems bids contract",
+            "tags": [],
+            "submittedBy": "Caranell",
+            "submissionTimestamp": "2025-03-13T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:0AC8E40E91AF1560CF9C9B38850FF76C36E398FCA5D4A25EC4DC2B0A269E3E64
Bounceable: EQAKyOQOka8VYM-cmziFD_dsNuOY_KXUol7E3CsKJp4-ZFgm
Non-bounceable: UQAKyOQOka8VYM-cmziFD_dsNuOY_KXUol7E3CsKJp4-ZAXj

It's a getgems-associated address for NFTs that users put up for sale
<img width="1167" alt="Screenshot 2025-03-13 at 22 44 51" src="https://github.com/user-attachments/assets/bb98d6cc-9b1b-428d-83ac-829d8c6c34f5" />
---- 
<img width="1457" alt="Screenshot 2025-03-13 at 22 45 05" src="https://github.com/user-attachments/assets/77ba2689-777d-4ea0-a635-9e0a77032d02" />
tx - https://tonviewer.com/transaction/3c571533a0fa97ed43befd0c1c4051342856140a311eb902a688bbdbd564db57