### PR TITLE
Add label for tonstation staking

### DIFF
--- a/assets/gaming/tonstation.json
+++ b/assets/gaming/tonstation.json
@@ -71,6 +71,14 @@
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-02-17T00:00:01Z"
+        },
+        {
+            "address": "EQBdygBKqmLWeF0YtBGXp7eZ5tc5h5C4In86aUhaXg06-xyK",
+            "source": "",
+            "comment": "jetton wallet for tonstation staking contract (EQCAnNP3yqPU8brDGWnMAD66uWdvXkeadh_5KOiJcNHI9OZv)",
+            "tags": [],
+            "submittedBy": "Caranell",
+            "submissionTimestamp": "2025-03-13T00:00:01Z"
         }
     ]
 }

--- a/assets/gaming/tonstation.json
+++ b/assets/gaming/tonstation.json
@@ -73,9 +73,9 @@
             "submissionTimestamp": "2025-02-17T00:00:01Z"
         },
         {
-            "address": "EQBdygBKqmLWeF0YtBGXp7eZ5tc5h5C4In86aUhaXg06-xyK",
+            "address": "EQCAnNP3yqPU8brDGWnMAD66uWdvXkeadh_5KOiJcNHI9OZv",
             "source": "",
-            "comment": "jetton wallet for tonstation staking contract (EQCAnNP3yqPU8brDGWnMAD66uWdvXkeadh_5KOiJcNHI9OZv)",
+            "comment": "Tonstation staking contract",
             "tags": [],
             "submittedBy": "Caranell",
             "submissionTimestamp": "2025-03-13T00:00:01Z"


### PR DESCRIPTION
HEX: 0:5dca004aaa62d6785d18b41197a7b799e6d7398790b8227f3a69485a5e0d3afb
Bounceable: EQBdygBKqmLWeF0YtBGXp7eZ5tc5h5C4In86aUhaXg06-xyK
Non-bounceable: UQBdygBKqmLWeF0YtBGXp7eZ5tc5h5C4In86aUhaXg06-0FP

This one is a bit tricky, it's a jetton wallet associated with staking contract (EQCAnNP3yqPU8brDGWnMAD66uWdvXkeadh_5KOiJcNHI9OZv), should we label this one or the contract address (or both)

![photo_2025-03-13_23-57-24](https://github.com/user-attachments/assets/6f5a5c60-8bc7-4995-9399-641be97a1a17)
