### PR TITLE
Add label for another splash airdrop address

### DIFF
--- a/assets/gaming/splash.json
+++ b/assets/gaming/splash.json
@@ -23,6 +23,14 @@
 					"tags": [],
 					"submittedBy": "rAndom1ze",
 					"submissionTimestamp": "2025-03-13T00:00:01Z"
+			},
+			{
+				"address": "EQCEA0bxUzklmmxhKt-c7qZw7-K2N-Xw8fCsUVZ8zt4zCbEg",
+				"source": "",
+				"comment": "Splash airdrop through tbook integration",
+				"tags": [],
+				"submittedBy": "Caranell",
+				"submissionTimestamp": "2025-03-15T00:00:01Z"
 			}
 	]
 }


### PR DESCRIPTION
HEX: 0:840346f15339259a6c612adf9ceea670efe2b637e5f0f1f0ac51567ccede3309
Bounceable: EQCEA0bxUzklmmxhKt-c7qZw7-K2N-Xw8fCsUVZ8zt4zCbEg
Non-bounceable: UQCEA0bxUzklmmxhKt-c7qZw7-K2N-Xw8fCsUVZ8zt4zCezl


<img width="820" alt="Screenshot 2025-03-15 at 14 19 00" src="https://github.com/user-attachments/assets/8933d7ef-5b6f-4fbe-b44a-24f025acdddd" />

It's an address for tbook x splash airdrop campaign, here're screenshots from tbook chat (apparently they have some claiming issues atm)

![photo_2025-03-15_14-22-06 (2)](https://github.com/user-attachments/assets/bc06ca86-db90-4149-acca-aff4954dd7c4)
![photo_2025-03-15_14-22-06](https://github.com/user-attachments/assets/0732e8e9-736b-48d0-b334-ccb5b37da354)
![photo_2025-03-15_14-22-05](https://github.com/user-attachments/assets/93290095-2f32-4439-baeb-5aba3356135a)
![photo_2025-03-15_14-23-45](https://github.com/user-attachments/assets/04926670-7cc9-47cb-9bae-8eedad4f5f8f)




My address for rewards: UQDeai4M51qCJnvxfJPl4U2S8MGJ9fx_0xb4fXjk8GewV-YD