### PR TITLE
Label possible botnet owner

### DIFF
--- a/assets/person/botnet_owner.json
+++ b/assets/person/botnet_owner.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+      "label": "joydaddev",
+      "category": "person",
+      "subcategory": "",
+      "website": "",
+      "description": "",
+      "organization": "individual"
+  },
+  "addresses": [
+      {
+          "address": "EQCuR0VTLu__zK6hBtcbYJzxZrCknZhkZCKDFzAYZiDFznL3",
+          "source": "",
+          "comment": "",
+          "tags": [],
+          "submittedBy": "Caranell",
+          "submissionTimestamp": "2025-03-15T00:00:00Z"
+      }
+  ]
+}


### PR DESCRIPTION
HEX: 0:ae4745532eefffccaea106d71b609cf166b0a49d98646422831730186620c5ce
Bounceable: EQCuR0VTLu__zK6hBtcbYJzxZrCknZhkZCKDFzAYZiDFznL3
Non-bounceable: UQCuR0VTLu__zK6hBtcbYJzxZrCknZhkZCKDFzAYZiDFzi8y

<img width="812" alt="Screenshot 2025-03-15 at 16 52 05" src="https://github.com/user-attachments/assets/a420c0d3-3868-4ceb-9b19-a5437201d324" />

I'm pretty confident in saying that this wallet is an accumulator for botnet of accounts that farmed splash and dogs airdrops.
Most of the accounts he interacted with look like that:
 
<img width="1181" alt="Screenshot 2025-03-15 at 16 54 13" src="https://github.com/user-attachments/assets/946cb791-d090-4b24-a646-59d529e1ab35" />
> gets some ton for fees
> claims tokens
> returns all tokens and leftover ton to the main

I wrote a small script and found at least 152 accounts with the exact behavior (and total of >2000 that send funds to this one but were funded from different sources). If you're interested in labeling these too, hmu, I'd be glad to help
 
----
My address for rewards: UQDeai4M51qCJnvxfJPl4U2S8MGJ9fx_0xb4fXjk8GewV-YD