### PR TITLE
Add labels proxy who use TG wallets

### DIFF
--- a/assets/cex/wallet_in_telegram.json
+++ b/assets/cex/wallet_in_telegram.json
@@ -95,6 +95,14 @@
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-02-19T00:03:33Z"
+        },
+        {
+            "address": "EQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7FIh",
+            "source": "tonviewer",
+            "comment": "Proxy Sender",
+            "tags": [],
+            "submittedBy": "rAndom1ze",
+            "submissionTimestamp": "2025-02-19T00:03:33Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:bb30f018b3d576e1de465fdd367ef68266c49e13ce28cf83c48ab482f23006ec
Bounceable:
EQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7FIh
Non-bounceable:
UQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7A_k


This wallet using like a proxy to send USDT for "Wallet in Telegram" users initiations.

We can see transactions all the same, wallet sending USDT to other wallets, we took any [trans](https://tonviewer.com/transaction/1a8e21af46d000a8068c438eb2d3717c1dcc7bc5c81ba991732672cdac016e31)
We pick any [wallet](https://tonviewer.com/UQBrs2gxaq9M9uvCpOk0p_BDCkEHIkUbSqth0MkV-2J3E_ud)
![image](https://github.com/user-attachments/assets/ad54c8af-3eef-4e72-9db7-7deafc01cfbf)

All of this wallet have same patern in transaction, like it

Money income from [OKX](https://tonviewer.com/transaction/27012d05a621ea427cb61113c6a67085c56252858a290715dc81098d4e6dcc9f) ByBit OKX
![image](https://github.com/user-attachments/assets/f0e0202e-5116-4fce-8729-fb75efdb1582)

