### PR TITLE
Add mytonwallet fee collector

### DIFF
--- a/assets/wallet/mytonwallet.json
+++ b/assets/wallet/mytonwallet.json
@@ -15,6 +15,14 @@
 					"tags": ["pool"],
 					"submittedBy": "rAndom1ze",
 					"submissionTimestamp": "2025-03-11T00:00:01Z"
+			},
+			{
+				"address": "EQDUkQbpTVIgt7v66-JTFR-3-eXRFz_4V66F-Ufn6vOg0D5s",
+				"source": "",
+				"comment": "fee collector from swaps within the wallet",
+				"tags": [],
+				"submittedBy": "Caranell",
+				"submissionTimestamp": "2025-04-15T00:00:01Z"
 			}
 	]
 }


### PR DESCRIPTION
HEX: 0:d49106e94d5220b7bbfaebe253151fb7f9e5d1173ff857ae85f947e7eaf3a0d0
Bounceable: EQDUkQbpTVIgt7v66-JTFR-3-eXRFz_4V66F-Ufn6vOg0D5s
Non-bounceable: UQDUkQbpTVIgt7v66-JTFR-3-eXRFz_4V66F-Ufn6vOg0GOp

<img width="510" alt="Screenshot 2025-04-15 at 11 40 25" src="https://github.com/user-attachments/assets/bb4868a1-0213-4fc6-a68d-4f97329218fa" />

The address is hardcoded in the mytonwallet config in their github repo
<img width="851" alt="Screenshot 2025-04-15 at 11 37 50" src="https://github.com/user-attachments/assets/7957514a-8e52-416c-a313-4b5e4dc69238" />

And, looking at transactions, it collects some % of tokens after users' swap
<img width="1272" alt="Screenshot 2025-04-15 at 11 42 17" src="https://github.com/user-attachments/assets/534f3762-b6cc-4cba-a738-43b9ebacdbcd" />

---

My address for rewards: UQDeai4M51qCJnvxfJPl4U2S8MGJ9fx_0xb4fXjk8GewV-YD