### PR TITLE
add tabdeal exchange

### DIFF
--- a/assets/cex/tabdeal.json
+++ b/assets/cex/tabdeal.json
@@ -1,0 +1,20 @@
+{
+    "metadata": {
+        "label": "tabdeal",
+        "category": "CEX",
+        "subcategory": "",
+        "website": "https://tabdeal.org",
+        "description": "",
+        "organization": "tabdeal"
+    },
+    "addresses": [
+        {
+            "address": "EQBmLDcxBiP21Vn4Jet3Th-DWyNl8JVmsbdAi8FvxHT38aiu",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "rawen7485",
+            "submissionTimestamp": "2025-04-18T13:29:55Z"
+        }
+    ]
+}


### PR DESCRIPTION
HEX:
0:662c37310623f6d559f825eb774e1f835b2365f09566b1b7408bc16fc474f7f1
Bounceable:
EQBmLDcxBiP21Vn4Jet3Th-DWyNl8JVmsbdAi8FvxHT38aiu
Non-bounceable:
UQBmLDcxBiP21Vn4Jet3Th-DWyNl8JVmsbdAi8FvxHT38fVr

This PR adds https://tabdeal.org to the list of exchanges.
Tabdeal is a cryptocurrency exchange based in Iran.

Let me know if any changes are needed.