### PR TITLE
add new address of wallet in telegram

### DIFF
--- a/assets/cex/wallet_in_telegram.json
+++ b/assets/cex/wallet_in_telegram.json
@@ -103,6 +103,14 @@
             "tags": [],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-19T00:03:33Z"
+        },
+        {
+            "address": "EQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7FIh",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "bI4ckb34rd",
+            "submissionTimestamp": "2025-04-19T14:14:34Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:bb30f018b3d576e1de465fdd367ef68266c49e13ce28cf83c48ab482f23006ec
Bounceable: EQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7FIh
Non-bounceable: UQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7A_k
My wallet: UQDJlovWgxZyuordryLGLBfHnKlINcCoVv1EHk2R2Yd6zULi

I believe that the address `UQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7A_k` belongs to Telegram’s wallet.

By analyzing the addresses that receive USDT, you’ll notice that shortly after receiving Tether, a small amount of TON with a comment like  
`transfer_1745070785_928ca818ad6120b5f2195b4f7fd53b704b43a766993076117b4e3ab114995553`  
is sent from a wallet (often associated with the Telegram wallet) to the same address.  
After this transfer, the address sends all received USDT back to the one that sent the TON.

you can use the following SQL query in dune to detect similar behavior for other wallets as well.  
Since I don’t have premium access, I’ve limited the query to 5,000 records, but you can increase that limit as needed:

```sql
SELECT tx_hash
FROM (
    SELECT tx_hash, comment
    FROM ton.messages
    WHERE block_date >= current_date - interval '7' day
    ORDER BY block_time DESC
    LIMIT 5000
) AS recent
WHERE REGEXP_LIKE(comment, '^transfer_.*_.*')
LIMIT 100;
```

the tonviewer doesn't show it correctly:
![image](https://github.com/user-attachments/assets/645be056-1036-46d2-839c-9c685b5a0e2d)
but you can see it better on tonscan:
![image](https://github.com/user-attachments/assets/4b3598fd-ef77-4a9f-850d-22a117a33a48)
