### PR TITLE
Add wuffi rewards address

### DIFF
--- a/assets/gaming/wuffi.json
+++ b/assets/gaming/wuffi.json
@@ -31,6 +31,14 @@
             "tags": [],
             "submittedBy": "markysha",
             "submissionTimestamp": "2025-03-10T00:00:00Z"
+        },
+        {
+            "address": "EQD0UCLjtWu5frYhlJvh6pi8AdKt6YHU4pgm8y00ziq8eGB7",
+            "source": "",
+            "comment": "TON Rewards Address",
+            "tags": [],
+            "submittedBy": "Caranell",
+            "submissionTimestamp": "2025-04-20T00:00:00Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:f45022e3b56bb97eb621949be1ea98bc01d2ade981d4e29826f32d34ce2abc78
Bounceable: EQD0UCLjtWu5frYhlJvh6pi8AdKt6YHU4pgm8y00ziq8eGB7
Non-bounceable: UQD0UCLjtWu5frYhlJvh6pi8AdKt6YHU4pgm8y00ziq8eD2-

<img width="532" alt="Screenshot 2025-04-20 at 10 22 48" src="https://github.com/user-attachments/assets/96451015-297d-49e4-9b0e-2542b70121ed" />

Address is hardcoded in telegram miniapp
<img width="984" alt="Screenshot 2025-04-20 at 10 22 19" src="https://github.com/user-attachments/assets/e56c4331-25ee-48b1-9af4-bf28a3ce59c2" />

And is used to claim WUF tokens
<img width="1184" alt="Screenshot 2025-04-20 at 10 26 17" src="https://github.com/user-attachments/assets/8c99606b-ffc2-4784-8e10-d408594917bc" />

---

My address for rewards: UQDeai4M51qCJnvxfJPl4U2S8MGJ9fx_0xb4fXjk8GewV-YD
