### PR TITLE
add wallex exchange

### DIFF
--- a/assets/cex/wallex.json
+++ b/assets/cex/wallex.json
@@ -1,0 +1,20 @@
+{
+    "metadata": {
+        "label": "wallex",
+        "category": "CEX",
+        "subcategory": "",
+        "website": "https://wallex.ir",
+        "description": "",
+        "organization": "wallex"
+    },
+    "addresses": [
+        {
+            "address": "EQDHuT2Kiu5svuOAQ9Jdu0jKaQ0TBwwxDf-3ouxHl8-RebaI",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "rawen7485",
+            "submissionTimestamp": "2025-04-20T15:29:48Z"
+        }
+    ]
+}


### PR DESCRIPTION
HEX:
0:c7b93d8a8aee6cbee38043d25dbb48ca690d13070c310dffb7a2ec4797cf9179
Bounceable:
EQDHuT2Kiu5svuOAQ9Jdu0jKaQ0TBwwxDf-3ouxHl8-RebaI
Non-bounceable:
UQDHuT2Kiu5svuOAQ9Jdu0jKaQ0TBwwxDf-3ouxHl8-ReetN

my wallet address:
UQAJ4ELQlXE5Ap3TfYUTKOEReR6EBMUrd38-A-_j8aLXTXFC

This PR adds https://wallex.ir to the list of exchanges.
wallex is a cryptocurrency exchange based in Iran.
![image](https://github.com/user-attachments/assets/4b60108b-7930-43af-92db-e12cec95d457)
