### PR TITLE
Add custodial wallet tag and label addresses

### DIFF
--- a/assets/cex/bingx.json
+++ b/assets/cex/bingx.json
@@ -36,9 +36,35 @@
             "address": "EQCf5Vv1OqJOU6e99JYdYwRhEKn5GqzuLEKzJKEC92zwgNm3",
             "source": "",
             "comment": "Deposit & Withdraw address",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-21T00:00:00Z"
+        },
+        {
+            "address": "EQB0PZcC1m2DSV8z8IiRok4WXqCnky2WdU8sF59EN4PCpPCh",
+            "source": "",
+            "comment": "Fee for custodial wallet",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-04-24T00:00:01Z"
+        },
+        {
+            "address": "EQAYXrXJuTlD0qE9tVaxVxu24a02Zy62U2Gz8txKWySilSez",
+            "source": "",
+            "comment": "Fee for custodial wallet",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-04-24T00:00:01Z"
+        },
+        {
+            "address": "EQBFmHGBV9b-StaWQ8g1DmydUEZWkidiBLI5ea9aonrcirp2",
+            "source": "",
+            "comment": "Withdrawal address",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-04-24T00:00:01Z"
         }
     ]
 }

--- a/assets/cex/bitget.json
+++ b/assets/cex/bitget.json
@@ -20,7 +20,9 @@
             "address": "EQDJlZqZfh1OQ4PY2ze4bSEBznjc8fGzkE2YiP5XLvDv1M6u",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
         },
@@ -28,7 +30,9 @@
             "address": "EQCnRoi95R9jLVrPONxTWEMMCuIlHBsYZjYZW5JwtoecbRl6",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
         },
@@ -36,14 +40,16 @@
             "address": "EQDN9_DXwJA28GQnLjxCntVwvknvKes6c1tku8F5FQc3MkZo",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
         },
         {
             "address": "EQAXl6XExQorMSzpkn_28S79OwtY_zEURRGMLS5kMStdeQng",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -51,7 +57,7 @@
         {
             "address": "EQAzZQL6-D71tTLTFbpxRQtmHJDoP85k2Lwf0r9kLzVV2VRy",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -59,7 +65,7 @@
         {
             "address": "EQBggwBbNUqxxHhaqM6Ck-5cnBgukkjyfpyQdPNcFjQggwrJ",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -67,7 +73,7 @@
         {
             "address": "EQDi0d8gazctsfO4kOYNGFtnqgyfG2tv9goFCRyMAbQKxMA3",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -75,7 +81,7 @@
         {
             "address": "EQCzCMf5tPWW9iUBdYhZclSYcbBccO02Gf1ak5QB7qly5Gsl",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -83,7 +89,7 @@
         {
             "address": "EQDpwKJP-qaqTyKIkOca6VUL_FOmxX5kO8McJA4YcnrBzlwi",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -91,7 +97,7 @@
         {
             "address": "EQBXPf6ZSQoEFwPpd-RyQTXFuL6gvqZ4OWEiR0UcqdXEywxy",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -99,7 +105,7 @@
         {
             "address": "EQB6DclNqfSLlo37h7441Pq3KGKI23oE0wgf7uF3N22QicZ7",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -107,7 +113,7 @@
         {
             "address": "EQDAflHltpSTd1j0X0ADBxyE9MSmi9sWiiLD1si4nNYYb7Kq",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "fees to custodial wallets",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -115,7 +121,7 @@
         {
             "address": "EQCHhe9euw_STGkR0Q9DwAlh6XSPpUKXoaxRfjxf52uwvmGB",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -123,7 +129,7 @@
         {
             "address": "EQDeJRmlJ95-HUwQKL23TgIrKKbjcOT-w_wn2NlxMI-Zu6i2",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -131,7 +137,7 @@
         {
             "address": "EQAGR25YDiUNCr7Fw2WnEYM0g8WB1XuQi-N9Vr2w4zjDEhg5",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -139,7 +145,7 @@
         {
             "address": "EQAhO2gEwgghNaSoA9qOOzDP7VGu6a8q0hADNLf0cR07zMQr",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"

--- a/assets/cex/bitmart.json
+++ b/assets/cex/bitmart.json
@@ -11,7 +11,7 @@
         {
             "address": "EQCi-sp63-vVxZcBCNH3kGXO8ysMFD-xNIkGa2hM3X7pXHfC",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "Memo deposits",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"

--- a/assets/cex/bittime.json
+++ b/assets/cex/bittime.json
@@ -11,7 +11,7 @@
         {
             "address": "EQArbzzaVnw4XwZFSG88ZlpFH1aylp0b5X2G63fGB3qB0fjP",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "Memo deposits",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"

--- a/assets/cex/bybit.json
+++ b/assets/cex/bybit.json
@@ -19,7 +19,7 @@
         {
             "address": "EQBkGAlMqAVTe2i9JR4DW0BlI25a6hhu5xgmhTdbdUWVQ7Vd",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "withdraws",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -27,7 +27,7 @@
         {
             "address": "EQCTMTmN2R2Fhbl9At-B9T0M5sgD0NBbRMsD6Lg592aXx7cC",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT operations",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -35,7 +35,7 @@
         {
             "address": "EQCMkj1lJzHOBGJmCNo7aQR-pE3qKdd0DWocr0XzDd_CErNz",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS operations",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -43,7 +43,7 @@
         {
             "address": "EQCZ-7akCw_dvl_Q5xyriWqCXdWubIPbuN7aDQlzX45paxCU",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -51,7 +51,7 @@
         {
             "address": "EQD-Q4vH7jEj2VL7T8fidxTsp-0NsC_qlnpJLImgbEPUotuj",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "NOT operations",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -59,7 +59,7 @@
         {
             "address": "EQBcqOrPFO0Z3glXWME_G3wt3bDG7fMIWJjigsjqgEnNlWot",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -75,7 +75,7 @@
         {
             "address": "EQCge0fy6N9JAnWDassuKu3WL5B4GADfzvmiT9wLok4YdPrI",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -83,7 +83,7 @@
         {
             "address": "EQACvGdEXPoGcwBK6RRdYZrwNYNNUN7OvTRVFIhUkwSCihtO",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -91,7 +91,7 @@
         {
             "address": "EQDPkB7XHgfCH34r9Yhqi7hw4mTEnpEQGY9C6RHiXHvsvdMF",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -99,7 +99,7 @@
         {
             "address": "EQCuf9xA0lPsnfpy2ux7qcKBk82Hg39vAUV0OS0AJQeNllht",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -107,7 +107,7 @@
         {
             "address": "EQDH5rK79LO771HqATmHCkXsIXEsQ3RGL-8sG4Q7rBJqa-wB",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -115,7 +115,7 @@
         {
             "address": "EQCtcRV4-JH-3AatB9l0_EXgBqH34QW2gveNoXr2ilMUr31Q",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -123,7 +123,7 @@
         {
             "address": "EQAamDt640mf7Hj6VtbtaLQjSXz9Bs421WmI1z1RnK0QMNcC",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -131,7 +131,7 @@
         {
             "address": "EQA4Po_6cQFtlGI5CENqKENLYtREeZpmpwwSV13dn73tozP3",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -139,7 +139,7 @@
         {
             "address": "EQDjzgXE2pdxMsJKOxAtqLX78uqRczN7Sd40bkpLBX91ebwy",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -147,7 +147,7 @@
         {
             "address": "EQAz26_Yc3sJt00JVhtVWdFU0aANpFQ5y133BeIVKpdAayJJ",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -155,7 +155,7 @@
         {
             "address": "EQDjPvhdF060V8By0e4QIVtpq5tkGS90ITAqscjia3rUvdWd",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -163,7 +163,7 @@
         {
             "address": "EQBNjyWlovsKRL7rJ0XzKplBF2qv2xfgZmXPRdtDTd5Ysx6A",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -171,7 +171,7 @@
         {
             "address": "EQDsWfZZ31JSSpYUb6zvmpgmF5o3nCBaNAEhxMunjXGgvUNx",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -179,7 +179,7 @@
         {
             "address": "EQCqDMN6cKPqetfkJlw6bcsXJrCB4-aKSSUaqJ0m37__DJgC",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -187,7 +187,7 @@
         {
             "address": "EQCnSlaxBareL0J_L4EL3Y8uvZfVMOYl53w9W5Xz6p261J4X",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -195,7 +195,7 @@
         {
             "address": "EQAVKL87Fv8ac0sftJcKhXTKRse3fBV3Wo5VI4-qhwwRORwb",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -203,7 +203,7 @@
         {
             "address": "EQAwssABs7N85Brq8Mqd0god5WqxqIxa69_4nMQmnbe7jTg5",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -211,7 +211,7 @@
         {
             "address": "EQDD8dqOzaj4zUK6ziJOo_G2lx6qf1TEktTRkFJ7T1c_fPQb",
             "source": "ton weekly slides",
-            "comment": "",
+            "comment": "deposit wallet",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T20:24:29Z"
@@ -219,7 +219,7 @@
         {
             "address": "EQAQ4UeX65WJVD_T75kZpIzQN73YncciF7JGCGPFSqS_6nxO",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -227,7 +227,7 @@
         {
             "address": "EQBM5h_UEcWDocyaj0yuc64T0wxMdTl8hUH2nUVjCCCiBgQt",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -235,7 +235,7 @@
         {
             "address": "EQBrLwaTp7NFXGwynoXfJDw_Z1ueRSOHmMvALt02IGTs3bDk",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -243,7 +243,7 @@
         {
             "address": "EQCOBNcg-c3zBAayjDRrFwKNkO3AqlPYmQr-NtnM4L9jeQz-",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -251,7 +251,7 @@
         {
             "address": "EQDNUlwVkE17QCfq4IsxhiQmDzcc6Mn0_MoM23tYOFQQfE_R",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -259,7 +259,7 @@
         {
             "address": "EQCuYqGS2pbiZhYacCzJ9t6RwMNEHxfOulG8RC37IDGjCmeU",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -267,7 +267,7 @@
         {
             "address": "EQBOElaNkAW5VWYHXfTKKBW7VZ_Qq2LFALQZV-w0VyC-_SdS",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -275,7 +275,7 @@
         {
             "address": "EQBKbwqmUgTXDmBCQwYzwXj1yekl8f6z-QDiu9XScPfPrXH9",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -283,7 +283,7 @@
         {
             "address": "EQCe0u-fw_z1IGtSWTTzKmKnG_YlpdNZ5xcyKO11ePR35Ee9",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -291,7 +291,7 @@
         {
             "address": "EQDhuvyJ6uWNAdbStENr92g2vqtulyh6eTkj3b-L6Yei2ZGY",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -299,7 +299,7 @@
         {
             "address": "EQBnO-yjjJfI4iXrSfc55zRY70N6ICfXkKvs_hkJTESCYmsM",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -307,7 +307,7 @@
         {
             "address": "EQD-7_Wc3tCVoVZe4JK7f9VXdpihUlTmRPJJUGHsJZiQBPpG",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -315,7 +315,7 @@
         {
             "address": "EQBUD5m_zbO4HULKy0riXSPxaWgbbfkqZQHl-MJUxd4Po5P4",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -323,7 +323,7 @@
         {
             "address": "EQDOnZ_XWOs_htava3KYlhVuggPxqXX6mOnc6lWk87lQKhTK",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -331,7 +331,7 @@
         {
             "address": "EQDhHpW6CI0PlUhJoZL3ciJ8PER57WTullqcsCwCMJuROQBm",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -339,7 +339,7 @@
         {
             "address": "EQD1AmltGL9X8y9Y0OZVITEHOZ5mCalvcqhEPUSM2gjes_Hk",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -347,7 +347,7 @@
         {
             "address": "EQBUrgTT-7tRTXpLz7vX_dOBVz58y10G2_q-fy0NJWOvGkYT",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -355,7 +355,7 @@
         {
             "address": "EQBGyNYC-fd3Nyib6ocruYAKSwx5VCWK5bjBsTPQpZG7-5UI",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -363,7 +363,7 @@
         {
             "address": "EQA7gSeV9mwW5ZvgUhYXPXC-VYxUDcvJUIv9whg1MNdO6uPN",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -371,7 +371,7 @@
         {
             "address": "EQCGZocc-KHkF2eabGFE0ydGGy28rqG-KwI6c5yp8hYI6EH6",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -379,7 +379,7 @@
         {
             "address": "EQB-ah_GFwD_xNl1jEDa9fMTYLCYNohOnhiuhJI3VJ_ure4G",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -387,7 +387,7 @@
         {
             "address": "EQDLLnL7QfqVevAYY9sVcJK_UQ-J9NkdJNEXTGGwKhdQ-Wiv",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -395,7 +395,7 @@
         {
             "address": "EQCHViRR3TcPCzRdn3S7a0gCbsCSplc8wCwuQLtsTk23U0Yv",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -403,7 +403,7 @@
         {
             "address": "EQBTMdR9Rv-kV1itjp2hyvl32bPGHMThep3auOQ0e8J8XBeL",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -411,7 +411,7 @@
         {
             "address": "EQAtIl_p6sevutsRKgduQp55zTcQEp9loW09UUoXCNIRu17c",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -419,7 +419,7 @@
         {
             "address": "EQDVAwC5qjB-RMoYhCIOsWHNHucIitq1HfKH0I2U49n8clGw",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -427,7 +427,7 @@
         {
             "address": "EQCGWXRiH9m-QjeFPCKNNnP90mgv5_6iG1sxHoQzRTkmO0nb",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -435,7 +435,7 @@
         {
             "address": "EQAEI52HvyWWRP6EDY1i3-sB5yIe9TaO1zDODscULKMfxKOC",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -443,7 +443,7 @@
         {
             "address": "EQDwiOozDblJ3ymw49Xn1fL_tzhwcBoJlU7f9hqn9yMpyW6O",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -451,7 +451,7 @@
         {
             "address": "EQBq8rnjhtsh6LJ7NiRkjZafWPGyQWVeyM5XEpX0c6Miuqtn",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -459,7 +459,7 @@
         {
             "address": "EQAUbrMMxr7lVdNnZJIoWCatWNcgquPNhu6j75zZ3MrGTfp4",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -467,7 +467,7 @@
         {
             "address": "EQAakaxdtFlKUvA-ZJbjs2f1RW0ydBzGcbj0EoxwFgj4R-j2",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -475,7 +475,7 @@
         {
             "address": "EQAoaAhEIhCRLy_jHKoM_xaNjtaMuposjT1ZrAZ7BghylnTx",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -483,7 +483,7 @@
         {
             "address": "EQDCLQgsIixKS2iLv_imxRwAcpq8bEqRv73pmnSC4QTN3ULh",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$NOT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -491,7 +491,7 @@
         {
             "address": "EQBrqaiJe7EHqkmkMSbhEa__0ZeerQnDnv0i1v1PkePlcrxT",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "$DOGS withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -499,7 +499,7 @@
         {
             "address": "EQAm5YIy8YPzwC_PMBvqSsgScmknIR8sfG3VtL71IMf_UrHv",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -507,7 +507,7 @@
         {
             "address": "EQBKHz68xmvc76kCRb31QaUK2hxoikh1NLFYer_9kwOINGaa",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -516,7 +516,9 @@
             "address": "EQB9Ez1OQlyOAN4BVROkTmbm0WOyHnFyCux1eZZeXeKMVV6_",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
@@ -524,7 +526,9 @@
             "address": "EQB_l_Nt2j997cnhL4wJxPief7wXUnqz9n3kw7FVKXpW5L0A",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
@@ -532,7 +536,9 @@
             "address": "EQBKHCC8mm-SlPdfHIen84OotzpIOi5tyzYw3b54s8ytANhS",
             "source": "Proof of reserves audit report: https://www.bybit.com/common-static/cht-static/por/Bybit_PoR_Audit_Nov.pdf",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-01T00:00:01Z"
         },
@@ -540,7 +546,9 @@
             "address": "EQDy3BhgaGzWWJh-K-2CFlMtjABEYNreqQfMfUrXI2xJa81w",
             "source": "Receive from Bybit 1,Bybit 7",
             "comment": "Receive from Bybit 1,Bybit 7",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "rAndom1ze",
             "submissionTimestamp": "2025-03-15T00:00:01Z"
         },
@@ -556,7 +564,9 @@
             "address": "EQDPfqI17W9lF-3OmAJu92GOn22BoTMdTmW6cY4s0V-ArRRY",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-15T00:00:01Z"
         },
@@ -564,7 +574,9 @@
             "address": "EQCtkG75GbHcDwN_ArpAkzD1Q-k0ou6goCzpBWnZP4ZjLfoA",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-16T00:00:01Z"
         },
@@ -572,7 +584,9 @@
             "address": "EQDL3cHsaI-70AIpXU7yvpBLj0qw1ip2z3V9zMfZV1WpXIk0",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-17T00:00:01Z"
         }

--- a/assets/cex/crypto.com.json
+++ b/assets/cex/crypto.com.json
@@ -11,7 +11,7 @@
         {
             "address": "EQBAL11PT4vqewvVEbnTdxg0waIru7yKMmA16weqJPXJ-Zdg",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "Memo deposits",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"

--- a/assets/cex/crypto_bot.json
+++ b/assets/cex/crypto_bot.json
@@ -12,7 +12,9 @@
             "address": "EQCtiv7PrMJImWiF2L5oJCgPnzp-VML2CAt5cbn1VsKAxLiE",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
@@ -20,7 +22,9 @@
             "address": "EQDshc_H_RAJNi5CG1oBQfUQ1lQBB6tz54Kf2h756Xp14_Cv",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "rdmcd",
             "submissionTimestamp": "2025-03-12T14:00:00Z"
         }

--- a/assets/cex/excoino.json
+++ b/assets/cex/excoino.json
@@ -11,7 +11,7 @@
         {
             "address": "EQCTTadEYfaUNSyOBy9WXL4SZONkbj0gUg-YQiJrTAang7PB",
             "source": "",
-            "comment": "",
+            "comment": "Memo deposits",
             "tags": [],
             "submittedBy": "rawen7485",
             "submissionTimestamp": "2025-04-20T14:05:41Z"

--- a/assets/cex/hitbtc.json
+++ b/assets/cex/hitbtc.json
@@ -13,8 +13,18 @@
             "address": "EQCLBw7bAacA8_akYkx-CG4DbahgYOuwTxmQjuYaNTczXzU3",
             "source": "",
             "comment": "hot wallet",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "shuva10v",
+            "submissionTimestamp": "2025-04-24T00:00:01Z"
+        },
+        {
+            "address": "EQALsnT-BEAc-4QcrqeG5SGoQc31Uw5TiklfB3zqm-Adngsv",
+            "source": "",
+            "comment": "fee sender",
+            "tags": [],
+            "submittedBy": "ohld",
             "submissionTimestamp": "2025-04-24T00:00:01Z"
         }
     ]

--- a/assets/cex/huobi.json
+++ b/assets/cex/huobi.json
@@ -23,6 +23,14 @@
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
+        },
+        {
+            "address": "EQC1DGum26DLyYKk7PCz0oi8H0_sWkDq6gXIvGV3GNJceEAb",
+            "source": "",
+            "comment": "deposits",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-04-24T00:00:01Z"
         }
     ]
 }

--- a/assets/cex/kraken.json
+++ b/assets/cex/kraken.json
@@ -12,7 +12,9 @@
             "address": "EQBdnCIFZhzSZVL-F96KEsruzUWfBlPHYCh_WBig95WoSuNE",
             "source": "Deposit & Withdraw address",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-20T00:00:01Z"
         }

--- a/assets/cex/lbank.info.json
+++ b/assets/cex/lbank.info.json
@@ -11,7 +11,7 @@
         {
             "address": "EQChSx9FI4Wyu5hK0sREHh0jyuBx_fwJbfulPrujtv8dENct",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "Deposit / Withdrawal address with memo",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"

--- a/assets/cex/metka.json
+++ b/assets/cex/metka.json
@@ -12,7 +12,9 @@
             "address": "EQA0Eout8-CBVUkbIhRLDDlnhUexfaRJrCC-NLXg6ukW_2Y7",
             "source": "",
             "comment": "Withdraw Address",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-03-16T00:00:01Z"
         }

--- a/assets/cex/okx.json
+++ b/assets/cex/okx.json
@@ -11,7 +11,7 @@
         {
             "address": "EQA0weM6cuoaaLEAd5kT8fFQR9INobWI6nkFcnx5tgeE0fC9",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -19,7 +19,7 @@
         {
             "address": "EQB2L56Q2zoqx-e_rn2LUJMVhV6f7njc6qkNJ0mEX6q7l22q",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -27,7 +27,7 @@
         {
             "address": "EQBHcPpzxBGFhp6A1A_MzPEvBIexogbXG2LEzyG5OPUjKriz",
             "source": "https://tonalytica.redoubt.online/queries/776/source",
-            "comment": "",
+            "comment": "TON withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T19:52:44Z"
@@ -347,7 +347,7 @@
         {
             "address": "EQB_LoTHI9i2trGqz4EMjCarI8IgIrRkuHEEstMGWw6nC3Nw",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "memo deposits",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -355,7 +355,7 @@
         {
             "address": "EQADON7zS4TG7pE0oEqxYBRQvkRjQKN64lneV8s3vbWQzWUO",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "memo deposits",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -363,7 +363,7 @@
         {
             "address": "EQAk2h57jakB5bPdD5jDl_625aXqSDGVqLa9BoLPLFMnrisV",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "USDT withdrawals",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -371,7 +371,7 @@
         {
             "address": "EQCbm3Od4lJ65y0hCD9RmNcQxyiEU7RzPlfsrbLhiayCnNuU",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "memo deposits",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"

--- a/assets/cex/okx.json
+++ b/assets/cex/okx.json
@@ -388,7 +388,9 @@
             "address": "EQBmoechltZNb69I-ksuqGH2ewSE0tFKWcr3AdjChs5E5RVn",
             "source": "",
             "comment": "received all assets from OKX9 wallet",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "rAndom1ze",
             "submissionTimestamp": "2025-02-14T01:01:01Z"
         },
@@ -420,7 +422,9 @@
             "address": "EQBsJbXy_l7xpqGXj2EfYaUIg_1QoIIrGRdkRfypMYIyY4ng",
             "source": "",
             "comment": "hot wallet",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-04-19T01:01:01Z"
         },

--- a/assets/cex/okx.json
+++ b/assets/cex/okx.json
@@ -386,7 +386,7 @@
         },
         {
             "address": "EQBmoechltZNb69I-ksuqGH2ewSE0tFKWcr3AdjChs5E5RVn",
-            "source": "",
+            "source": "USDT withdrawals",
             "comment": "received all assets from OKX9 wallet",
             "tags": [
                 "has-custodial-wallets"

--- a/assets/cex/tabdeal.json
+++ b/assets/cex/tabdeal.json
@@ -11,7 +11,7 @@
         {
             "address": "EQBmLDcxBiP21Vn4Jet3Th-DWyNl8JVmsbdAi8FvxHT38aiu",
             "source": "",
-            "comment": "",
+            "comment": "Memo deposits",
             "tags": [],
             "submittedBy": "rawen7485",
             "submissionTimestamp": "2025-04-18T13:29:55Z"

--- a/assets/cex/toobit.json
+++ b/assets/cex/toobit.json
@@ -12,7 +12,9 @@
             "address": "EQAaBt63Ciw74awysnWRiJEqzcA0d_Jt_TdS_tICAbOvUCRS",
             "source": "",
             "comment": "Withdraw Address",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-03-19T00:00:01Z"
         }

--- a/assets/cex/wallet_in_telegram.json
+++ b/assets/cex/wallet_in_telegram.json
@@ -12,7 +12,9 @@
             "address": "EQCRiHBZulagN5CwaW16QCrAaR3_YvzTmOgT-X07Jzb6WLfa",
             "source": "ton weekly slides",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T20:24:29Z"
         },
@@ -20,7 +22,9 @@
             "address": "EQAfWAbHPQO7yW637r8WBn8fLo4nDPoW1XABqp6vdFbwCAb0",
             "source": "ton weekly slides",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T20:24:29Z"
         },
@@ -28,7 +32,9 @@
             "address": "EQDPBslO_a4m-qodhQkvxNrueOugnmnDbawFHB2P_eNfQF_w",
             "source": "ton weekly slides",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T20:24:29Z"
         },
@@ -36,7 +42,9 @@
             "address": "EQCXrZNESRUInoEiOP8Qq-kGbQsD6j26KoYw-5yfiKpFXPqY",
             "source": "ton weekly slides",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-11-25T20:24:29Z"
         },
@@ -44,7 +52,9 @@
             "address": "EQAbROxVNhaw5FUQNwOINL3wvaofBEDhDzMx2YQVhWEqaHD0",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
@@ -52,7 +62,9 @@
             "address": "EQBugU5kUOjFeAZ7tlYpj7TQE5fdFQGNfzTcNp6rpMIRHLwm",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
@@ -60,7 +72,9 @@
             "address": "EQBDanbCeUqI4_v-xrnAN0_I2wRvEIaLg1Qg2ZN5c6Zl1KOh",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
@@ -68,14 +82,16 @@
             "address": "EQDd3NPNrWCvTA1pOJ9WetUdDCY_pJaNZVq0JMaara-TIp90",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
         {
             "address": "EQCj22Hf6cbLcmWuvU3EhDEvRW6tFEH7ts_LFbbZzNyJ9YG_",
             "source": "",
-            "comment": "",
+            "comment": "multisig_v2",
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-02-19T00:03:33Z"
@@ -83,7 +99,7 @@
         {
             "address": "EQBMunNB4UlTyogGUjHTLR3vYUKuJbHUxh0-b5nQHmd6RP57",
             "source": "",
-            "comment": "",
+            "comment": "multisig_v2",
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-02-19T00:03:33Z"
@@ -91,7 +107,7 @@
         {
             "address": "EQDucGxDQdjRQ7LG6cmsteM5sSq0K6uGn0fKl3VrCGlJ74GY",
             "source": "",
-            "comment": "",
+            "comment": "multisig_v2",
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-02-19T00:03:33Z"
@@ -100,7 +116,9 @@
             "address": "EQBYLl3J6XKqTGCUR1i7pmWdPVyGokGROY4PuMAjr1UzdKVm",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-19T00:03:33Z"
         },
@@ -108,7 +126,9 @@
             "address": "EQBkKkBXXPyAtM9EFvirAVVXiNidK87hOi4E7v5CcVy83JI-",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "jeffdsm6426",
             "submissionTimestamp": "2025-04-20T08:53:33Z"
         },
@@ -116,7 +136,9 @@
             "address": "EQDdb_AsWWNHRVKbmajVvu6p9sOKkYjmp-lqQk44IMisCi7d",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-04-23T00:00:01Z"
         },
@@ -124,7 +146,9 @@
             "address": "EQACOJWu-VUCSSCikcbzcV4pHfGz3SVOr6iwniGi1Y1Yl_UA",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-04-23T00:00:01Z"
         }

--- a/assets/cex/wallex.json
+++ b/assets/cex/wallex.json
@@ -11,7 +11,7 @@
         {
             "address": "EQDHuT2Kiu5svuOAQ9Jdu0jKaQ0TBwwxDf-3ouxHl8-RebaI",
             "source": "",
-            "comment": "",
+            "comment": "Memo deposits",
             "tags": [],
             "submittedBy": "rawen7485",
             "submissionTimestamp": "2025-04-20T15:29:48Z"

--- a/assets/cex/whitebit.json
+++ b/assets/cex/whitebit.json
@@ -11,7 +11,7 @@
         {
             "address": "EQAigd8MjqsJejMuIB0UPhErOlGe22dezkpjvpWt9kOrtkG8",
             "source": "",
-            "comment": "Deposit & Withdraw Address",
+            "comment": "Deposit & Withdraw Address, memo",
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-01-20T07:07:33Z"

--- a/assets/cex/xrocket.json
+++ b/assets/cex/xrocket.json
@@ -12,7 +12,9 @@
             "address": "EQABGo8KCza3ea8DNHMnSWZmbRzW-05332eTdfvW-XDQEjQM",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
@@ -20,14 +22,16 @@
             "address": "EQB1cmpxb3R-YLA3HLDV01Rx6OHpMQA_7MOglhqL2CwJx_dz",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },
         {
             "address": "EQBFYU_uOZxD13u1l1WHkYMbwO4xdUy7K1sfv1o0iO2ZQDLL",
             "source": "datalake-test.cex_labels_20241116",
-            "comment": "",
+            "comment": "cold wallet",
             "tags": [],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
@@ -36,7 +40,9 @@
             "address": "EQDB3GVLWYq4TNpPEjcu_tiQfO3wkBhlpYZJCHNz4BscJPaV",
             "source": "datalake-test.cex_labels_20241116",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         },

--- a/assets/gaming/1xbet.json
+++ b/assets/gaming/1xbet.json
@@ -12,7 +12,9 @@
             "address": "EQBHLwAD21SgZeRavXI9aBH6RWorHLr41mHYAUcH_v7G2Iy2",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "RomanHF",
             "submissionTimestamp": "2025-03-17T00:00:01Z"
         }

--- a/assets/gaming/dinodrop.json
+++ b/assets/gaming/dinodrop.json
@@ -12,7 +12,9 @@
             "address": "EQD5AKgQvurjOvYRWy3sHASNgRclr-beO0O-bgUdjFyBPi1G",
             "source": "",
             "comment": "Deposit address",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-03-20T00:00:01Z"
         },
@@ -20,7 +22,9 @@
             "address": "EQDJA1Nv4hNyH5W6w4QCPQ6xKxRtFJ8Uqr7Iyu8GoGqKcbbC",
             "source": "",
             "comment": "Deposit address",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "rAndom1ze",
             "submissionTimestamp": "2025-04-14T00:00:01Z"
         }

--- a/assets/gaming/rebor.json
+++ b/assets/gaming/rebor.json
@@ -25,12 +25,28 @@
             "submissionTimestamp": "2025-03-24T00:00:01Z"
         },
         {
-          "address": "EQBuw7HFbmAVsMu54czANErtujCFz4KzxliFSc6EXhtkVwDb",
-          "source": "",
-          "comment": "",
-          "tags": [],
-          "submittedBy": "Caranell",
-          "submissionTimestamp": "2025-03-24T00:00:01Z"
-      }
+            "address": "EQBuw7HFbmAVsMu54czANErtujCFz4KzxliFSc6EXhtkVwDb",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "Caranell",
+            "submissionTimestamp": "2025-03-24T00:00:01Z"
+        },
+        {
+            "address": "EQBZ5xbqHsE9Oki92dUdIFBN4FEadWY9n-QwoAPj-mlZYK8E",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-04-24T00:00:01Z"
+        },
+        {
+            "address": "EQCmt2GTwzgct3pnG6T0coQgdNQylX02s2fjWzb_t6UWucHA",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2025-04-24T00:00:01Z"
+        }
     ]
 }

--- a/assets/gaming/rebor.json
+++ b/assets/gaming/rebor.json
@@ -31,22 +31,6 @@
             "tags": [],
             "submittedBy": "Caranell",
             "submissionTimestamp": "2025-03-24T00:00:01Z"
-        },
-        {
-            "address": "EQBZ5xbqHsE9Oki92dUdIFBN4FEadWY9n-QwoAPj-mlZYK8E",
-            "source": "",
-            "comment": "",
-            "tags": [],
-            "submittedBy": "ohld",
-            "submissionTimestamp": "2025-04-24T00:00:01Z"
-        },
-        {
-            "address": "EQCmt2GTwzgct3pnG6T0coQgdNQylX02s2fjWzb_t6UWucHA",
-            "source": "",
-            "comment": "",
-            "tags": [],
-            "submittedBy": "ohld",
-            "submissionTimestamp": "2025-04-24T00:00:01Z"
         }
     ]
 }

--- a/assets/gaming/ton_miner.json
+++ b/assets/gaming/ton_miner.json
@@ -12,7 +12,9 @@
             "address": "EQBHtWly9rEAaYLZIRXuP4ciGdOqP8shsUuO_XVs-_xpY3Tq",
             "source": "Deposit address",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-23T00:00:01Z"
         }

--- a/assets/gaming/tonpoker.json
+++ b/assets/gaming/tonpoker.json
@@ -12,7 +12,9 @@
             "address": "EQB1QBhyiY76wtIDTaV3pFtl8jE_aCrlGeDDTRbz2LaNjWYC",
             "source": "",
             "comment": "Deposit address",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-03-20T00:00:01Z"
         },
@@ -20,7 +22,9 @@
             "address": "EQA_E56TdEqPTlI85DI8iEQ2rygUwsFbQO7NpTeUcLxipde3",
             "source": "",
             "comment": "Deposit address",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-03-21T00:00:01Z"
         },

--- a/assets/gaming/voxel.json
+++ b/assets/gaming/voxel.json
@@ -12,7 +12,9 @@
             "address": "EQAcNHtyWeV2ApYmeDBsJwWljIUrDl3-sB5x7Bq8kEzuIFS3",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "dddwhdd",
             "submissionTimestamp": "2025-04-15T00:00:01Z"
         }

--- a/assets/gaming/whalecasino.json
+++ b/assets/gaming/whalecasino.json
@@ -12,7 +12,9 @@
             "address": "EQDxap_cQvPmSGQlmclkDxemuaOjMZgLoXDHOzmAHsIGiY2o",
             "source": "",
             "comment": "",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ch4rter",
             "submissionTimestamp": "2025-03-04T00:00:01Z"
         }

--- a/assets/merchant/cryptomus.json
+++ b/assets/merchant/cryptomus.json
@@ -23,7 +23,9 @@
             "address": "EQDn-EI7rtBBpt_lCj4wAtwrUAwQyl8f_gn_LftTIub2ET4q",
             "source": "",
             "comment": "Crypto Acquiring",
-            "tags": [],
+            "tags": [
+                "has-custodial-wallets"
+            ],
             "submittedBy": "ziga",
             "submissionTimestamp": "2024-12-12T10:09:26Z"
         }

--- a/tags.json
+++ b/tags.json
@@ -70,5 +70,9 @@
     {
         "name": "pool",
         "description": "Liquidity pool"
+    },
+    {
+        "name": "has-custodial-wallets",
+        "description": "Has custodial wallets which send deposits to this address"
     }
 ]


### PR DESCRIPTION
These orgs doesn't have deposits via custodial wallets for now:

```
        'pocketfi', 'miomi_game', 'wcoin', 
        'paws', 'goblin_mine', 'boinkers',
        'pluto_studio',

        'binance', 'fixedfloat', 'mexc', 'fragment', 'gameness', 'pixiland', 
        'huobi', 'gate.io', 'tonnel', 'bridgers', 'redcoin', '0xiceberg',
        'omni_points', 'bountybay', 'memhash', 'tonstakers', 'nobitex', 'split.tg', 'dropee',
        'vertus', 'blum', 'seed_analytics', 'goats', 'tomarket', 'not_pixel', 'tonstation',
        'memefi', 'okx', 'sidekick_labs', 'bbq_coin', 'yescoin', 'piggypiggy', 'tonkeeper', 'dedust', 'bums', 'rebor',
        'cwallet', 'bitpin', 'coinex', 'kucoin', 'ton.fun', 'major', 'nexusverse', 'major',
        'starhash', 'merge_pals', 'money_dogs', 'marketapp', 'wonton'

```

These ones have:
```
        'wallet_in_telegram', 'tonpoker', 'metka', 'cryptomus', 'xrocket', '1xbet', 'bybit', 'bitget', 
        'whale', 'crypto_bot', 'dinodrop', 'toobit', 'voxel', 'hitbtc', 'ton_miner'
```