### PR TITLE
add notpixel

### DIFF
--- a/assets/gaming/not_pixel.json
+++ b/assets/gaming/not_pixel.json
@@ -31,6 +31,14 @@
             "tags": [],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-01-23T00:00:01Z"
+        },
+        {
+            "address": "EQASEhZfTWtuI6801v1tkOJkMGrr5yynLG8ck7OuE_KukX5t",
+            "source": "",
+            "comment": "PX Staking contract",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-05-01T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:1212165f4d6b6e23af34d6fd6d90e264306aebe72ca72c6f1c93b3ae13f2ae91
Bounceable: EQASEhZfTWtuI6801v1tkOJkMGrr5yynLG8ck7OuE_KukX5t
![IMG_20250501_090826](https://github.com/user-attachments/assets/30dfb9a8-fe49-495d-bec4-2d8c13380a60)

This address is the NotPixel staking NFT contract.
It is already displayed on Tonviewer:
![IMG_20250501_090841](https://github.com/user-attachments/assets/976f553e-eef5-49eb-a9dd-a96f4cb53fd6)
