### PR TITLE
add new wallet_in_telegram

### DIFF
--- a/assets/cex/wallet_in_telegram.json
+++ b/assets/cex/wallet_in_telegram.json
@@ -111,6 +111,14 @@
             "tags": [],
             "submittedBy": "jeffdsm6426",
             "submissionTimestamp": "2025-04-20T08:53:33Z"
+        },
+        {
+            "address": "EQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7FIh",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-05-01T00:00:00Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:bb30f018b3d576e1de465fdd367ef68266c49e13ce28cf83c48ab482f23006ec
Bounceable: EQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7FIh
Non-bounceable: UQC7MPAYs9V24d5GX902fvaCZsSeE84oz4PEirSC8jAG7A_k

![IMG_20250501_101409](https://github.com/user-attachments/assets/5a8bf80c-3630-4635-9dc9-f7002d97a9a7)

This is a USDT custodial wallet for Wallet in Telegram as only USDT transactions are found here:
![IMG_20250501_141013](https://github.com/user-attachments/assets/c940003a-e5e5-40ff-94bb-797757f6b59d)

Transactions on this address executes a contract which withdraws USDT from this address, sends to another address and finally ends up in a Wallet in Telegram address.
Here is an example from an address via the OKX TON Explorer (https://web3.okx.com/explorer/ton/address/EQBqx3YQWnedr2Ml_2GMw3QoUbzSIVmpNc1YLxC-neYLx5WF):
![IMG_20250501_141659](https://github.com/user-attachments/assets/a9e79a3d-10bb-43bd-8871-7c13c70b09fe)
![IMG_20250501_141717](https://github.com/user-attachments/assets/8627ef58-6fe4-4d5c-afb3-b72844a405bc)

Tonviewer doesn't show the address receiving USDT but it shows the transfer to Wallet in Telegram which always uses a known memo always used by @Wallet:
![IMG_20250501_142443](https://github.com/user-attachments/assets/93835178-8e6d-4aa6-997b-c8f61ce5cd57)

