### PR TITLE
Add ecorpay airdrop address

### DIFF
--- a/assets/merchant/ecorpay.json
+++ b/assets/merchant/ecorpay.json
@@ -1,0 +1,20 @@
+{
+  "metadata": {
+      "label": "ecorpay",
+      "category": "merchant",
+      "subcategory": "",
+      "website": "https://token.ecorpay.com/",
+      "description": "",
+      "organization": "ecorpay"
+  },
+  "addresses": [
+      {
+          "address": "EQCQ3XICarr2Zyt8Jjus18AdkInf6Zqmrxx24DtJqFdbtaAr",
+          "source": "",
+          "comment": "Ecor token airdrop distributor",
+          "tags": [],
+          "submittedBy": "Caranell",
+          "submissionTimestamp": "2025-05-11T00:00:01Z"
+      }
+  ]
+}

--- a/assets/merchant/ecorpay.json
+++ b/assets/merchant/ecorpay.json
@@ -3,7 +3,7 @@
       "label": "ecorpay",
       "category": "merchant",
       "subcategory": "",
-      "website": "https://token.ecorpay.com/",
+      "website": "https://token.ecorpay.com",
       "description": "",
       "organization": "ecorpay"
   },


### PR DESCRIPTION
HEX: 0:90dd72026abaf6672b7c263bacd7c01d9089dfe99aa6af1c76e03b49a8575bb5
Bounceable: EQCQ3XICarr2Zyt8Jjus18AdkInf6Zqmrxx24DtJqFdbtaAr
Non-bounceable: UQCQ3XICarr2Zyt8Jjus18AdkInf6Zqmrxx24DtJqFdbtf3u

<img width="507" alt="Screenshot 2025-05-11 at 12 19 09" src="https://github.com/user-attachments/assets/f968d714-620a-43c4-a6e5-cc5165c3d8dc" />

Address is distributing ECOR token to different addresses
<img width="1181" alt="Screenshot 2025-05-11 at 12 19 41" src="https://github.com/user-attachments/assets/c7e15e42-b137-4c81-a54d-064486e620c1" />

It was funded from the token owner in two transactions ([1](https://tonviewer.com/transaction/cbd55204d1dde525ce002721755af996fff7fe69bf7c6be33a2821886396aa66), [2](https://tonviewer.com/transaction/fe7115830ee96879c6b5d93395838acbeed70078355e7403cf3f134bfa8d7efb)) or 12mil tokens
_owner and airdrop address in token top holders list_
<img width="1177" alt="Screenshot 2025-05-11 at 12 21 33" src="https://github.com/user-attachments/assets/4b751ad7-428e-4622-a34f-8f02d386ec2a" />

I added it to merchant because ecorpay.com seems to be a legit payment provider, and the token landing page is hosted on their subdomain

---

My address for rewards: UQDeai4M51qCJnvxfJPl4U2S8MGJ9fx_0xb4fXjk8GewV-YD