### PR TITLE
bitpin

### DIFF
--- a/assets/cex/bitpin.json
+++ b/assets/cex/bitpin.json
@@ -47,6 +47,14 @@
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-04-27T01:01:01Z"
+        },
+         {
+            "address": "EQD2FXQ479dnUK_Keg4FxTDYMn8Drf2QyghwMJKfO4Qj_667",
+            "source": "",
+            "comment": "bitpin withdrawal address",
+            "tags": [],
+            "submittedBy": "Lucky4truli",
+            "submissionTimestamp": "2025-05-14T01:01:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:f6157438efd76750afca7a0e05c530d8327f03adfd90ca087030929f3b8423ff
Bounceable: EQD2FXQ479dnUK_Keg4FxTDYMn8Drf2QyghwMJKfO4Qj_667
Non-bounceable: UQD2FXQ479dnUK_Keg4FxTDYMn8Drf2QyghwMJKfO4Qj__N-
My wallet : UQBicUiXrZqxzPExSjw4UP4a4ltFscS-cX50SeLj4_eZ-4uN
![image](https://github.com/user-attachments/assets/e9e13c37-4245-4944-b7cb-8ac596bcb881)
I believe this address belongs to Bitpin, and here's why:
The constant donor is this address, which also frequently transfers large amounts to Bitpin exchange wallets.
![image](https://github.com/user-attachments/assets/f4b88a25-9d66-468e-a497-1de6e3a4053f)
![image](https://github.com/user-attachments/assets/bdea30a1-7c4d-447e-8e72-916dc6193cc5)
https://tonviewer.com/UQA00C9oip9TkHbFdYgYGi149vhFPfdZyxYuWmHo6dD1mhxY
For example, let's consider the Major token. The listing on the exchange took place on November 28. On the same day, tokens were transferred from the previously mentioned donor address.
![image](https://github.com/user-attachments/assets/92f35c97-d646-4f9c-a4a1-93bcabba84df)
https://t.me/bitpin/1182
Similarly, an analogy can be drawn with the already labeled Bitpin address, which is also a withdrawal wallet, and the donor was still the same address mentioned earlier.
![image](https://github.com/user-attachments/assets/132431d5-0254-4eff-8316-30e5c663d7bc)


