### PR TITLE
Add puparty withdrawals address

### DIFF
--- a/assets/gaming/puparty.json
+++ b/assets/gaming/puparty.json
@@ -15,6 +15,14 @@
             "tags": [],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-04-23T00:00:01Z"
+        },
+        {
+            "address": "EQCOLJO2dvJsXJ1UNyxzeTwuTEvaJXzr4inqrxehPEKg28Ay",
+            "source": "",
+            "comment": "Smart contract handling withdrawals",
+            "tags": [],
+            "submittedBy": "Caranell",
+            "submissionTimestamp": "2025-05-21T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:8e2c93b676f26c5c9d54372c73793c2e4c4bda257cebe229eaaf17a13c42a0db
Bounceable: EQCOLJO2dvJsXJ1UNyxzeTwuTEvaJXzr4inqrxehPEKg28Ay
Non-bounceable: UQCOLJO2dvJsXJ1UNyxzeTwuTEvaJXzr4inqrxehPEKg2533

<img width="590" alt="Screenshot 2025-05-21 at 20 05 07" src="https://github.com/user-attachments/assets/36ebb22c-79af-492a-aa3b-bbd95b718517" />

The wallets triggering this smart contract are being topped up from the marked puparty address

<img width="1173" alt="Screenshot 2025-05-21 at 20 03 51" src="https://github.com/user-attachments/assets/098e08cd-8c44-41cd-8b02-b4f89331c1e5" />

And the admins in official chat are saying that withdrawals are made through this contract

<img width="848" alt="Screenshot 2025-05-21 at 20 07 34" src="https://github.com/user-attachments/assets/aa47a50b-eeba-4956-9454-0b10550ca0b8" />

[tx address in message](https://tonviewer.com/transaction/6684e1cd8b1874951ecfa4b10d2e9c48afe68695ff14a504200d28e296d580ef)

<img width="1195" alt="Screenshot 2025-05-21 at 20 08 07" src="https://github.com/user-attachments/assets/0b62794c-569f-41e3-9679-2e1b9ce03582" />


---

My address for rewards: UQDeai4M51qCJnvxfJPl4U2S8MGJ9fx_0xb4fXjk8GewV-YD