### PR TITLE
bitpin

### DIFF
--- a/assets/cex/bitpin.json
+++ b/assets/cex/bitpin.json
@@ -47,6 +47,14 @@
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-04-27T01:01:01Z"
+        },
+         {
+            "address": "EQD2FXQ479dnUK_Keg4FxTDYMn8Drf2QyghwMJKfO4Qj_667",
+            "source": "",
+            "comment": "bitpin withdrawal address",
+            "tags": [],
+            "submittedBy": "Lucky0041",
+            "submissionTimestamp": "2025-05-25T01:01:01Z"
         }
     ]
 }

--- a/assets/cex/bitpin.json
+++ b/assets/cex/bitpin.json
@@ -51,7 +51,15 @@
          {
             "address": "EQD2FXQ479dnUK_Keg4FxTDYMn8Drf2QyghwMJKfO4Qj_667",
             "source": "",
-            "comment": "bitpin withdrawal address",
+            "comment": "withdrawal address",
+            "tags": [],
+            "submittedBy": "Lucky0041",
+            "submissionTimestamp": "2025-05-25T01:01:01Z"
+        },
+     {
+            "address": "EQCC_mFH94cDlv4646XncwQEub4BWztG57Aoam1IynCLBmXo",
+            "source": "",
+            "comment": "withdrawal address",
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-05-25T01:01:01Z"


### PR DESCRIPTION
HEX: 0:f6157438efd76750afca7a0e05c530d8327f03adfd90ca087030929f3b8423ff
Bounceable: EQD2FXQ479dnUK_Keg4FxTDYMn8Drf2QyghwMJKfO4Qj_667
Non-bounceable: UQD2FXQ479dnUK_Keg4FxTDYMn8Drf2QyghwMJKfO4Qj__N-
![image](https://github.com/user-attachments/assets/c935acf4-ec22-4527-aff6-8138422301c6)


HEX: 0:82fe6147f7870396fe3ae3a5e7730404b9be015b3b46e7b0286a6d48ca708b06
Bounceable: EQCC_mFH94cDlv4646XncwQEub4BWztG57Aoam1IynCLBmXo
Non-bounceable: UQCC_mFH94cDlv4646XncwQEub4BWztG57Aoam1IynCLBjgt
![image](https://github.com/user-attachments/assets/ad2362e1-08f8-45f2-8d5e-15cea16e233d)
My wallet : UQBicUiXrZqxzPExSjw4UP4a4ltFscS-cX50SeLj4_eZ-4uN

Proofs based on which I believe these two addresses belong to Bitpin: I made a deposit as well as a withdrawal: 
![image](https://github.com/user-attachments/assets/fbcd45fe-f64f-46ed-afe7-62749a076acd)
![image](https://github.com/user-attachments/assets/acfe9e39-050f-4228-9a0e-db94aa7b7f5d)
https://tonviewer.com/transaction/2b6c61133dfe0e7371f69d7e7542ad0eef85df3d7b885740c18009a0bd4cd750
https://tonviewer.com/transaction/56e7f17275dab9b455d7674f407b149b0c5611958c8ff1c8f01a5f883f849b48
If we analyze the address from which the withdrawal was received, we’ll see that it was funded from only one address, and the wallet itself only sends out funds. By drawing an analogy with the other two addresses, the situation is similar
1) 1 - This is the address that has already been labeled and from which I received the withdrawal from Bitpin. We can see that the funds are coming from (UQA00) 
https://intel.arkm.com/explorer/address/0:9731F2C7A941457EDD586F6A366B1F3ADA2A1F34F9C5FE5E14D8907233E9D128
![image](https://github.com/user-attachments/assets/e8e08e16-9cd4-4c8f-af98-1b5e22a2e01f)


2) The address we are investigating shows a similar pattern 
![image](https://github.com/user-attachments/assets/6b66fbf2-5d6e-4cad-b74c-94393ba60189)
https://intel.arkm.com/explorer/address/0:F6157438EFD76750AFCA7A0E05C530D8327F03ADFD90CA087030929F3B8423FF

3) The address we are investigating shows a similar pattern 
![image](https://github.com/user-attachments/assets/5e011349-30cd-4429-962b-8cd1f5de188b)
https://intel.arkm.com/explorer/address/0:82FE6147F7870396FE3AE3A5E7730404B9BE015B3B46E7B0286A6D48CA708B06
Although I wasn't able to make a direct transaction, based on their on-chain activity — the fact that they only send funds, receive them only from the Bitpin wallet, and show the same pattern as the already confirmed Bitpin withdrawal wallet — it can be concluded that these addresses also belong to the Bitpin exchange

Also, taking into account the somewhat old withdrawal from the Bitpin exchange from the required address, which also confirms their affiliation with Bitpin
![image](https://github.com/user-attachments/assets/cbdc6bcb-050a-4080-8250-5919e7827b49)
https://tonviewer.com/transaction/436f65ab48711fc1c246a5ad893fea3356c47e0142908c8050775354f0d850da