### PR TITLE
setup reward for contribute

### DIFF
--- a/.github/workflows/reward.yml
+++ b/.github/workflows/reward.yml
@@ -1,0 +1,29 @@
+name: Reward
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  reward:
+    name: Reward
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: the-ton-tech/toolchain/reward@v1.3.0
+        with:
+          # https://society.ton.org/ton-addresses-labelling-contributor
+          activity_id: 9865
+          xps_min: 0
+          xps_max: 10000
+          # (optional) label for marking the rewarded PR
+          # on_reward_label: rewarded
+          # Credentials of TON Society Platform
+          society_api_key: ${{ secrets.SOCIETY_API_KEY }}
+          society_partner_id: ${{ secrets.SOCIETY_PARTNER_ID }}
+          # GitHub token used to read PR details and post comments/labels
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
- [ ] **Setup actions variables (https://github.com/ton-studio/ton-labels/settings/secrets/actions):** `SOCIETY_API_KEY` and `SOCIETY_PARTNER_ID`
- [ ] (optional) **Create new label (https://github.com/ton-studio/ton-labels/labels) for example:** name="rewarded" description="
Awards user SBT reward for merged PR" color="#008672"

> [!IMPORTANT]
> By default, the XPS value is 0, it must be overridden at the final review stage by adding a comment in the review in the format `XPS=N`, where `N` is a positive integer from 0 to `<xps_max>`, if the value is 0, no reward is given
