### PR TITLE
Add new not_pixel address

### DIFF
--- a/assets/gaming/not_pixel.json
+++ b/assets/gaming/not_pixel.json
@@ -149,6 +149,14 @@
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-06-18T00:00:01Z"
+        },
+        {
+            "address": "EQDwyD-8xgjcz6LI2Kqc-trQIBYrYsrpkpbUVuhCCoJBtxj4",
+            "source": "",
+            "comment": "tournament 2",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-06-20T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:f0c83fbcc608dccfa2c8d8aa9cfadad020162b62cae99296d456e8420a8241b7
Bounceable: EQDwyD-8xgjcz6LI2Kqc-trQIBYrYsrpkpbUVuhCCoJBtxj4
Non-bounceable: UQDwyD-8xgjcz6LI2Kqc-trQIBYrYsrpkpbUVuhCCoJBt0U9

![image](https://github.com/user-attachments/assets/ab25a3c1-48ad-47bf-b7df-aecde473d2d8)

This address belongs to NotPixel. Proofs:
Received tokens from a labelled NotPixel address (EQBv3exBKLmQcn2Fm6VlntAInW-je1YP4U59gJxaO62NC37i)
![image](https://github.com/user-attachments/assets/1a8c07b8-eb65-42c0-9bf8-75d88681ac41)

And interacts with the NotPixel jetton address (EQAN9bDXNo662Jy9CuClZ6McqUt3oohs2aedF2OeH3o72n0Z):
![image](https://github.com/user-attachments/assets/ecbaa52c-15d8-4927-aa1c-a70088ffc056)

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0
