### PR TITLE
Add GiftAutoBuyer labels

### DIFF
--- a/assets/merchant/giftautobuyer.json
+++ b/assets/merchant/giftautobuyer.json
@@ -1,0 +1,21 @@
+{
+    "metadata": {
+        "label": "giftautobuyer",
+        "name": "GiftAutoBuyer",
+        "organization": "giftautobuyer",
+        "category": "merchant",
+        "subcategory": "",
+        "description": "TG Stars marketplace",
+        "website": "https://t.me/AutoGiftRobot"
+    },
+    "addresses": [
+        {
+            "address": "EQD_5QW00WeqQJBojrQvxyYOxhrb4mD7qVCpVV56rRTxUy2x",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "GloriaKinsburg",
+            "submissionTimestamp": "2025-07-08T17:00:02Z"
+        }
+    ]
+} 


### PR DESCRIPTION
HEX: 0:ffe505b4d167aa4090688eb42fc7260ec61adbe260fba950a9555e7aad14f153
Bounceable: EQD_5QW00WeqQJBojrQvxyYOxhrb4mD7qVCpVV56rRTxUy2x
Non-bounceable: UQD_5QW00WeqQJBojrQvxyYOxhrb4mD7qVCpVV56rRTxU3B0
![image](https://github.com/user-attachments/assets/869386d6-909b-45d5-9039-0e3500e3dd43)
My wallet : UQAjecHzmpKf8dkLDdI80RBZy39mEYoLn3LMx8RWe1lObcCu
This address belongs to the owner of the [AutoGiftNews channel](https://t.me/AutoGiftNews). This is supported by several factors: first, the address is linked to the Telegram domain autobuygift, which was acquired by the owner; second, the channel itself contains mentions of a refund and features advertisements presumably promoting their own auto-buy bot for purchasing gifts.
![image](https://github.com/user-attachments/assets/8421185a-eeeb-4240-b883-ec51c2dd7a69)
![image](https://github.com/user-attachments/assets/3fcd4184-e0dc-4f44-ab94-b1f9543fb1d5)
https://t.me/AutoGiftNews/802 - Mention of a refund

