### PR TITLE
sticker_bot

### DIFF
--- a/assets/merchant/sticker_bot.json
+++ b/assets/merchant/sticker_bot.json
@@ -91,7 +91,7 @@
         {
             "address": "EQApvLZ1LDIgGHQYTqXoKAUQXOxCsz9D8dVz7_7SH-WwEJx7",
             "source": "",
-            "comment": "",
+            "comment": "Sappy stickers sale",
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-07-09T00:00:01Z"


### PR DESCRIPTION
HEX: 0:29bcb6752c32201874184ea5e82805105cec42b33f43f1d573effed21fe5b010
Bounceable: EQApvLZ1LDIgGHQYTqXoKAUQXOxCsz9D8dVz7_7SH-WwEJx7
Non-bounceable: UQApvLZ1LDIgGHQYTqXoKAUQXOxCsz9D8dVz7_7SH-WwEMG-
![image](https://github.com/user-attachments/assets/4ddb3d1d-608c-4352-a1db-763b5b41bd1d)
My wallet: UQBicUiXrZqxzPExSjw4UP4a4ltFscS-cX50SeLj4_eZ-4uN
The address was used to refund funds following participation in a sticker raffle.
1) https://t.me/SappySealsTG/33 
![image](https://github.com/user-attachments/assets/d1da51c9-f528-4c68-9eb0-b15ff6bce895)
https://tonviewer.com/UQBMe_UjQ2U8QzARFts5KB2DhRb-ygDLASDgHP5aiiypMudt
As we can see from this wallet, participants were sending 15 TON yesterday to the previously identified Sticker Store address ([thedns-tg-channel.ton](https://tonviewer.com/EQDSMBKWC7fs5Lb31BhVM8yElKrWnAePLLJyOlecxJgimenO)). These funds were then transferred to a new wallet with minimal activity, and subsequently to an address used for issuing refunds. Today, users have started receiving their refunds.
2) 
![image](https://github.com/user-attachments/assets/952ff738-9009-47ec-ac05-c465110a3bd1)
There were 11,844 participants and 1,500 winners, meaning there should be 10,344 refunds issued.
![image](https://github.com/user-attachments/assets/d90b78da-5e33-421b-9c91-868274bd8aa9)
