### PR TITLE
Add new Nobitex addresses

### DIFF
--- a/assets/cex/nobitex.json
+++ b/assets/cex/nobitex.json
@@ -47,6 +47,22 @@
             "tags": [],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-04-22T00:00:01Z"
+        },
+        {
+            "address": "EQDeokJviFMgvQocUk_b7Q-dt3UC7kOWtaEaqDnOBpeJt9dB",
+            "source": "",
+            "comment": "withdrawal address",
+            "tags": [],
+            "submittedBy": "Lexichnek",
+            "submissionTimestamp": "2025-07-12T00:00:01Z"
+        },
+        {
+            "address": "EQBhsmwzM0X9_1Aj3dCWUXWYNIjj0JAPoB3e2iXiVrOTKvAq",
+            "source": "",
+            "comment": "withdrawal address",
+            "tags": [],
+            "submittedBy": "Lexichnek",
+            "submissionTimestamp": "2025-07-12T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
1) HEX: 0:dea2426f885320bd0a1c524fdbed0f9db77502ee4396b5a11aa839ce069789b7
Bounceable: EQDeokJviFMgvQocUk_b7Q-dt3UC7kOWtaEaqDnOBpeJt9dB
Non-bounceable: UQDeokJviFMgvQocUk_b7Q-dt3UC7kOWtaEaqDnOBpeJt4qE
<img width="1004" height="541" alt="image" src="https://github.com/user-attachments/assets/96617d98-1384-4b50-951d-c2e7a4cadbd4" />
2) HEX: 0:61b26c333345fdff5023ddd0965175983488e3d0900fa01ddeda25e256b3932a
Bounceable: EQBhsmwzM0X9_1Aj3dCWUXWYNIjj0JAPoB3e2iXiVrOTKvAq
Non-bounceable: UQBhsmwzM0X9_1Aj3dCWUXWYNIjj0JAPoB3e2iXiVrOTKq3v
<img width="634" height="534" alt="image" src="https://github.com/user-attachments/assets/b746c4d3-4af8-43a7-9d30-4f3daec6e3c5" />
My wallet for rewards: UQAjecHzmpKf8dkLDdI80RBZy39mEYoLn3LMx8RWe1lObcCu

Proofs:
I believe that these two addresses belong to the Nobitex exchange and are used for withdrawals, and here’s why I think so:
https://intel.arkm.com/explorer/address/0:61B26C333345FDFF5023DDD0965175983488E3D0900FA01DDEDA25E256B3932A
https://intel.arkm.com/explorer/address/0:dea2426f885320bd0a1c524fdbed0f9db77502ee4396b5a11aa839ce069789b7
<img width="1107" height="941" alt="image" src="https://github.com/user-attachments/assets/1c31c959-d1b2-4dc9-8dae-de5b690780d8" />
After analyzing the transactions, we can see that these addresses only send funds out and have received large amounts from the same wallet repeatedly: UQDDsF6s6MEzTHpeN3oMFrTgK-ydjkb4EGXo4JFoVPaoBFto.
By checking this address, we can see notable memo fields coming from a labeled Nobitex exchange address, containing the text: "test"
<img width="1594" height="686" alt="image" src="https://github.com/user-attachments/assets/5dfcfb6a-eb71-4fd7-a7c2-634b88edc447" />
https://tonviewer.com/UQBdWoMOSCFHkfSrU1KQDGJNO_88Xv1jAZaxgBWOt4mZDwmZ
Here we can see that withdrawals from regular users stopped back in May. Since then, the transactions have been uniform and appear to be made by the Nobitex administration, with corresponding identifiers. Therefore, I believe that due to the exchange being compromised, these two new addresses were introduced for withdrawals. The transaction history shows only outgoing transfers, and the volumes involved strongly suggest that the addresses belong to the exchange. Furthermore, the previously provided evidence supports the claim that they are indeed associated with Nobitex.

