### PR TITLE
Add Dedust address

### DIFF
--- a/assets/dex/dedust.json
+++ b/assets/dex/dedust.json
@@ -196,13 +196,6 @@
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-06-12T00:00:01Z"
         },
-        {
-            "address": "EQAAoyu0C-aMYGPVEoMfuAge2-meJWeO5KLJKrKWJAJAKXGL",
-            "source": "",
-            "comment": "",
-            "tags": [],
-            "submittedBy": "JackReachy",
-            "submissionTimestamp": "2025-08-01T00:00:01Z"
          {
             "address": "EQBCAUfvMMSn-WHP0bKDs4wUVOK1r55OuHJIq25_QnVFCFye",
             "source": "",
@@ -218,6 +211,14 @@
             "tags": [],
             "submittedBy": "Lexichnek",
             "submissionTimestamp": "2025-07-14T00:00:01Z"
+        },
+        {
+            "address": "EQAAoyu0C-aMYGPVEoMfuAge2-meJWeO5KLJKrKWJAJAKXGL",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "JackReachy",
+            "submissionTimestamp": "2025-08-01T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:00a32bb40be68c6063d512831fb8081edbe99e25678ee4a2c92ab29624024029
Bounceable: EQAAoyu0C-aMYGPVEoMfuAge2-meJWeO5KLJKrKWJAJAKXGL
Non-bounceable: UQAAoyu0C-aMYGPVEoMfuAge2-meJWeO5KLJKrKWJAJAKSxO
<img width="831" height="475" alt="image" src="https://github.com/user-attachments/assets/33acfa70-029c-491f-b53a-3b1209ce9dd9" />
My wallet : UQBqDUtXzQ42H41hDPj9nN9vs7q4zFzhX-rArtIVZ8DOoFai
<img width="1664" height="675" alt="image" src="https://github.com/user-attachments/assets/0407a5a6-6baf-4a44-9589-ae24bd5b23cf" />
<img width="1637" height="722" alt="image" src="https://github.com/user-attachments/assets/33b6e7ae-0de5-412f-8213-d2bd96885112" />
Based on the transaction execution path and the contract calls to DedustSwapExternal, DedustPayoutFromPool, and DedustPayout, it can be stated with high confidence that these contracts and the associated addresses belong to the Dedust protocol and are used for swap operations and fund distribution within its pool.


