### PR TITLE
Add tonstation address (Update tonstation.json)

### DIFF
--- a/assets/gaming/tonstation.json
+++ b/assets/gaming/tonstation.json
@@ -9,6 +9,14 @@
     },
     "addresses": [
         {
+            "address": "EQBiqXZKDq6wisFeDgyMWyYTvjP_CLZZ5qe-ftn2Uy0IVt67",
+            "source": "",
+            "comment": "$SOON sender address",
+            "tags": [],
+            "submittedBy": "Matsharik",
+            "submissionTimestamp": "2025-08-02T13:39:01Z"
+        },
+        {
             "address": "EQC7m1us8wg8AED2J_L8qq_mtiSSbXZuXu90q0jYqVqRiHK6",
             "source": "",
             "comment": "",


### PR DESCRIPTION
Адрес EQBiqXZKDq6wisFeDgyMWyYTvjP_CLZZ5qe-ftn2Uy0IVt67 (0:62a9764a0eaeb08ac15e0e0c8c5b2613be33ff08b659e6a7be7ed9f6532d0856) располагает достаточно большим объемом токенов SOON и рассылает их по разным адресам. Вряд ли так будет делать кто-либо, кроме создателя токена. А создателем токена является Ton Station.
<img width="1529" height="515" alt="image" src="https://github.com/user-attachments/assets/68fec349-6c8d-4c39-8661-d3954272f6af" />
<img width="1597" height="843" alt="image" src="https://github.com/user-attachments/assets/70477c7f-8607-49b5-9461-fc383dd11ff1" />
<img width="1475" height="741" alt="image" src="https://github.com/user-attachments/assets/103bcf96-f116-4a39-92e6-722dbb38465d" />
Мой адрес для +4 тон: UQB6q2-AH_s44GpnP7Q8_p_LGfUYdvKUBZex884BmmsieYpR. Спасибо!