### PR TITLE
Add HelperStars address

### DIFF
--- a/assets/merchant/helperstars.json
+++ b/assets/merchant/helperstars.json
@@ -16,6 +16,14 @@
             "tags": [],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-07-10T17:00:02Z"
+        },
+        {
+            "address": "EQBKQEG5d7ZVevZWUpeJ524d6q_xTAZNj8MCoSK8-2GLz4WU",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "NotVredina",
+            "submissionTimestamp": "2025-08-03T17:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:4a4041b977b6557af656529789e76e1deaaff14c064d8fc302a122bcfb618bcf
Bounceable: EQBKQEG5d7ZVevZWUpeJ524d6q_xTAZNj8MCoSK8-2GLz4WU
Non-bounceable: UQBKQEG5d7ZVevZWUpeJ524d6q_xTAZNj8MCoSK8-2GLz9hR
<img width="967" height="507" alt="image" src="https://github.com/user-attachments/assets/c960e0f6-c24d-45fa-9096-cefb061d78be" />
My wallet : UQBqDUtXzQ42H41hDPj9nN9vs7q4zFzhX-rArtIVZ8DOoFai
<img width="620" height="947" alt="image" src="https://github.com/user-attachments/assets/e4cf15e9-346e-4330-85f6-3e4e1888973f" />
When you open the app and tap on the option to purchase stars, a message with the payment details will appear, which will include the address (in this case, a TON DNS name) that matches the one we need to label.