### PR TITLE
Add Sticker_bot address

### DIFF
--- a/assets/merchant/sticker_bot.json
+++ b/assets/merchant/sticker_bot.json
@@ -111,6 +111,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-07-17T00:00:01Z"
+        },
+        {
+            "address": "EQDbf6jUgQPfDywn5ordm9MQK0Kd5bDwECyhp7g8hebSCv47",
+            "source": "",
+            "comment": "TG Stars withdrawal address",
+            "tags": [],
+            "submittedBy": "JackReachy",
+            "submissionTimestamp": "2025-08-05T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:db7fa8d48103df0f2c27e68add9bd3102b429de5b0f0102ca1a7b83c85e6d20a
Bounceable: EQDbf6jUgQPfDywn5ordm9MQK0Kd5bDwECyhp7g8hebSCv47
Non-bounceable: UQDbf6jUgQPfDywn5ordm9MQK0Kd5bDwECyhp7g8hebSCqP-
<img width="811" height="492" alt="image" src="https://github.com/user-attachments/assets/1dd6752b-94f8-4aec-8115-c71be6d636f6" />
My wallet  : UQBqDUtXzQ42H41hDPj9nN9vs7q4zFzhX-rArtIVZ8DOoFai
I believe this address belongs to the Sticker Store based on the following facts: 
1) The transfer of funds received from the conversion of stars into TON to the multisig address of the sticker bot

<img width="1475" height="615" alt="image" src="https://github.com/user-attachments/assets/332b9a6c-d001-4b39-9ae5-3d56a0589e86" />

2) An analogy can be made with the already labeled address of the sticker bot, which is also a signer on this multisig wallet. 
-  https://tonviewer.com/UQA9ufTbNOu9O6pUKT3rIM_hoWIuIluv3vQWB68s3NJgb-7M
<img width="1524" height="369" alt="image" src="https://github.com/user-attachments/assets/e7c08dcb-55a0-42cf-af5d-6264681ac7c3" />
<img width="1520" height="750" alt="image" src="https://github.com/user-attachments/assets/6452952b-6dd4-44eb-b34f-fdcc6f1adac9" />

We will see identical behavior. Therefore, based on the specific behavior and the rather large transfer to the sticker bot's multisig address, I consider it correct to conclude that this address also belongs to the Sticker Store team