### PR TITLE
Add new Bipin address

### DIFF
--- a/assets/cex/bitpin.json
+++ b/assets/cex/bitpin.json
@@ -56,13 +56,21 @@
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-05-25T01:01:01Z"
         },
-     {
+        {
             "address": "EQCC_mFH94cDlv4646XncwQEub4BWztG57Aoam1IynCLBmXo",
             "source": "",
             "comment": "withdrawal address",
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-05-25T01:01:01Z"
+        },
+        {
+            "address": "EQAXhGlA1gdX-eqB6ClephUjdHSxfNj0Mt9fnCw8zl1Xtp94",
+            "source": "",
+            "comment": "withdrawal address",
+            "tags": [],
+            "submittedBy": "JackReachy",
+            "submissionTimestamp": "2025-08-13T01:01:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:17846940d60757f9ea81e8295ea615237474b17cd8f432df5f9c2c3cce5d57b6
Bounceable: EQAXhGlA1gdX-eqB6ClephUjdHSxfNj0Mt9fnCw8zl1Xtp94
Non-bounceable: UQAXhGlA1gdX-eqB6ClephUjdHSxfNj0Mt9fnCw8zl1XtsK9
My wallet : UQBqDUtXzQ42H41hDPj9nN9vs7q4zFzhX-rArtIVZ8DOoFai
<img width="805" height="506" alt="image" src="https://github.com/user-attachments/assets/631174d9-c43e-4506-b6a4-7f16378a93bf" />
I believe this address belongs to the Bitpin exchange because of the high volumes, specific activity, and the fact that this wallet only makes withdrawals, while the funds for these withdrawals come exclusively from a Bitpin address that sends only to other Bitpin addresses (as clearly shown by the labels in TON Viewer).
<img width="1112" height="830" alt="image" src="https://github.com/user-attachments/assets/44624058-c226-4c71-8a78-8a7318b8ec83" />

https://intel.arkm.com/explorer/address/0:17846940D60757F9EA81E8295EA615237474B17CD8F432DF5F9C2C3CCE5D57B6

https://tonviewer.com/EQA00C9oip9TkHbFdYgYGi149vhFPfdZyxYuWmHo6dD1mkGd
<img width="1495" height="810" alt="image" src="https://github.com/user-attachments/assets/56d971ef-35f4-4890-beb2-37602c485217" />
