### PR TITLE
Add wcoin TG stars withdrawal address

### DIFF
--- a/assets/gaming/wcoin.json
+++ b/assets/gaming/wcoin.json
@@ -15,6 +15,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-08-31T00:00:01Z"
+        },
+        {
+            "address": "EQBRegY3KdPgbcN8tb9Delq2lwEBiSfDSENaKb8s3-8yd9Nu",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-09-07T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
<img width="814" height="400" alt="image" src="https://github.com/user-attachments/assets/35bcdbef-e9c8-4746-b5d8-a5aeec2fd469" />

HEX:
0:517a063729d3e06dc37cb5bf437a5ab69701018927c348435a29bf2cdfef3277
Bounceable: UQBRegY3KdPgbcN8tb9Delq2lwEBiSfDSENaKb8s3-8yd46r
Non-bounceable: EQBRegY3KdPgbcN8tb9Delq2lwEBiSfDSENaKb8s3-8yd9Nu

This address receives TON from Fragment (Stars withdrawal) and sends it to wcoin.ton (already labelled):
<img width="1226" height="833" alt="image" src="https://github.com/user-attachments/assets/9270e819-5c3f-4ebc-a8d9-7dae2a01db93" />

Also has the wcoin collectible username:
<img width="718" height="639" alt="image" src="https://github.com/user-attachments/assets/44559b7b-6668-4b4b-bf97-02dacc3226fd" />

