### PR TITLE
update Ludogift

### DIFF
--- a/assets/gaming/ludogift.json
+++ b/assets/gaming/ludogift.json
@@ -15,6 +15,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-07-17T00:00:01Z"
+        },
+         {
+            "address": "EQB5WtKIzXu9P9EbEE2d-lxK4R_bjP3MB_hc0PfSFeOW7hgk",
+            "source": "",
+            "comment": "Telegram Stars cash out address",
+            "tags": [],
+            "submittedBy": "JackReachy",
+            "submissionTimestamp": "2025-09-08T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
<img width="1202" height="312" alt="image" src="https://github.com/user-attachments/assets/6195957d-a715-4cc5-ac19-6561e83dcaab" />

HEX: 0:795ad288cd7bbd3fd11b104d9dfa5c4ae11fdb8cfdcc07f85cd0f7d215e396ee
Bounceable: EQB5WtKIzXu9P9EbEE2d-lxK4R_bjP3MB_hc0PfSFeOW7hgk
Non-bounceable: UQB5WtKIzXu9P9EbEE2d-lxK4R_bjP3MB_hc0PfSFeOW7kXh
My wallet for rewards: UQBqDUtXzQ42H41hDPj9nN9vs7q4zFzhX-rArtIVZ8DOoFai

By reviewing the transactions, we can see that the address received Plush Pepe #1084 as well as two anonymous numbers from the address: UQA850_Qp1bwixBYHIYw0H1TaDX3MvMyYuXRZbBG6PJFBX_u, which were obtained free of charge.

Analyzing the source address and comparing it with the one we are trying to label, we notice an anonymous number that, when linked to the corresponding profile, reveals that the owner is associated with the Ludogift application.

Additional evidence is the very specific activity of this address:

  -  receiving collectibles directly from an address clearly tied to Ludogift,
 -  receiving TON from TG Stars withdraw

This strongly suggests that the address in question belongs to the owner of Ludogift

<img width="1504" height="547" alt="image" src="https://github.com/user-attachments/assets/c6fb53cb-f7f3-428a-aba8-4eaf421bed90" />

<img width="1212" height="803" alt="image" src="https://github.com/user-attachments/assets/28483de6-28a2-4b47-b72a-a23bd5a112c5" />
<img width="484" height="657" alt="image" src="https://github.com/user-attachments/assets/4110689b-3de3-47d6-bb07-113ab89d9614" />
