### PR TITLE
Update drft_party 

### DIFF
--- a/assets/gaming/drft_party.json
+++ b/assets/gaming/drft_party.json
@@ -39,6 +39,14 @@
             "tags": [],
             "submittedBy": "shuva10v",
             "submissionTimestamp": "2025-05-27T00:00:01Z"
+        },
+        {
+            "address": "EQAS4Ol2_P8BcYZDpFJVYFEPP1QRVinh7GT-t7A3cTbUO1Nh",
+            "source": "",
+            "comment": "Telegram Stars cash out address",
+            "tags": [],
+            "submittedBy": "JackReachy",
+            "submissionTimestamp": "2025-09-08T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:12e0e976fcff01718643a4525560510f3f54115629e1ec64feb7b0377136d43b
Bounceable: EQAS4Ol2_P8BcYZDpFJVYFEPP1QRVinh7GT-t7A3cTbUO1Nh
Non-bounceable: UQAS4Ol2_P8BcYZDpFJVYFEPP1QRVinh7GT-t7A3cTbUOw6k
My wallet for rewards: UQBqDUtXzQ42H41hDPj9nN9vs7q4zFzhX-rArtIVZ8DOoFai 
<img width="1229" height="280" alt="image" src="https://github.com/user-attachments/assets/8742125e-21f6-4ae4-a93c-b02d33452fa7" />

https://tonviewer.com/0:12E0E976FCFF01718643A4525560510F3F54115629E1EC64FEB7B0377136D43B - This is the address we want to label, and we can see regular withdrawals to Binance with the identifier 139700786.

There is also another address, already labeled as drft_party and used for internal deposits — EQAPoDm5igucGRpMI3L8wPmO6gNGuhusQOM7L_9NGgQo903s.

From this address, we sometimes observe large withdrawals with the same identifier. It is safe to assume that these transactions are carried out by the project team. Therefore, I believe these addresses are connected.