### PR TITLE
Add new label walletstars

### DIFF
--- a/assets/merchant/walletstars.json
+++ b/assets/merchant/walletstars.json
@@ -20,7 +20,7 @@
         {
             "address": "EQBW7qiNsccs-cENcEPLK9fMqDV7uQib0wkzEb0HgSIPy9ml",
             "source": "",
-            "comment": "",
+            "comment": "Telegram Stars cash out address",
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-09-08T00:00:01Z"


### PR DESCRIPTION
HEX:
0:56eea88db1c72cf9c10d7043cb2bd7cca8357bb9089bd3093311bd0781220fcb
Bounceable: EQBW7qiNsccs-cENcEPLK9fMqDV7uQib0wkzEb0HgSIPy9ml
Non-bounceable: EQBW7qiNsccs-cENcEPLK9fMqDV7uQib0wkzEb0HgSIPy9ml
DNS: zaspa.ton

<img width="1643" height="428" alt="Screenshot from 2025-09-08 23-24-24" src="https://github.com/user-attachments/assets/90deeecc-cd3f-42e1-ae4a-8f755501deb4" />

This address sends TON to two different walletstars frequently:
<img width="1663" height="596" alt="Screenshot from 2025-09-08 23-36-52" src="https://github.com/user-attachments/assets/d748f92b-801d-4234-bb52-cfbace431064" />

One of the addresses with DNS walletstars.ton is a deposit address used in the bot:
<img width="1518" height="721" alt="image" src="https://github.com/user-attachments/assets/77f9219f-3c68-4d27-b963-a6c97eb74b53" />
Notice that a memo is used for user deposits as seen below from the miniapp, but zaspa.ton doesn't include a memo. This can only mean it is used by the team to fund walletstars.ton:
<img width="417" height="888" alt="Screenshot from 2025-09-08 23-23-03" src="https://github.com/user-attachments/assets/963434bb-aa30-47f1-8eee-8438bda347c1" />
 
The second address with DNS walletstars-2.ton is used for the sole purpose of buying stars for users so any TON received from zaspa.ton and other addresses can only be from the team:
<img width="1518" height="721" alt="image" src="https://github.com/user-attachments/assets/ddd1e4ca-9dbd-4c0a-9b9d-d72f660b064f" />


My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0