### PR TITLE
add new puparty label

### DIFF
--- a/assets/gaming/puparty.json
+++ b/assets/gaming/puparty.json
@@ -39,6 +39,14 @@
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-06-18T00:00:01Z"
+        },
+        {
+            "address": "EQBB-XNSb5AcNNPrmFiBDuxevvlxAGtP3Fht-RbgS9-OwXJU",
+            "source": "",
+            "comment": "Telegram Stars cash out address",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-09-11T00:00:00Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:41f973526f901c34d3eb9858810eec5ebef971006b4fdc586df916e04bdf8ec1
Bounceable: EQBB-XNSb5AcNNPrmFiBDuxevvlxAGtP3Fht-RbgS9-OwXJU
Non-bounceable: UQBB-XNSb5AcNNPrmFiBDuxevvlxAGtP3Fht-RbgS9-OwS-R

<img width="830" height="420" alt="Screenshot from 2025-09-11 15-21-51" src="https://github.com/user-attachments/assets/0d68fa4b-b8a1-4f6e-9f27-769a1331e365" />

This address usually interacts with UQB-J99_ocX-M_E2heNK5kLcTNk06o1YPOmkLVPHlsg6IS6H (an address already labelled as Puparty):
<img width="1305" height="897" alt="image" src="https://github.com/user-attachments/assets/032d6d1f-429f-42ae-b2f3-85771d331547" />

The Puparty address (UQB-J99_ocX-M_E2heNK5kLcTNk06o1YPOmkLVPHlsg6IS6H) only interacts with a Puparty smart contract:
<img width="1305" height="897" alt="image" src="https://github.com/user-attachments/assets/2eae4f27-d6b7-498d-b70b-f362384862ce" />

We can also see that only a handful of addresses include the one we are labelling have sent TON to UQB-J99_ocX-M_E2heNK5kLcTNk06o1YPOmkLVPHlsg6IS6H which can only mean it is the team making the transactions:
<img width="951" height="311" alt="image" src="https://github.com/user-attachments/assets/4239e862-1789-4172-8bf7-629a6caa5dff" />

My address:
UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0