### PR TITLE
Create elephantstore.json

### DIFF
--- a/assets/merchant/elephantstore.json
+++ b/assets/merchant/elephantstore.json
@@ -3,7 +3,7 @@
         "label": "elephantstore",
         "name": "ElephantStore",
         "category": "merchant",
-        "subcategory": "",
+        "subcategory": "offchain_marketplace",
         "website": "https://t.me/ElephantStoreBot",
         "description": "",
         "organization": "elephantstore"

--- a/assets/merchant/elephantstore.json
+++ b/assets/merchant/elephantstore.json
@@ -1,0 +1,21 @@
+{
+    "metadata": {
+        "label": "elephantstore",
+        "name": "ElephantStore",
+        "category": "merchant",
+        "subcategory": "",
+        "website": "https://t.me/ElephantStoreBot",
+        "description": "",
+        "organization": "elephantstore"
+    },
+    "addresses": [
+        {
+            "address": "EQBVHnZBVt0VrB4EZSEbIuPTojZJ0wu-1lfLb017TfA6pQVH",
+            "source": "",
+            "comment": "Telegram Stars cashout address and NFT deployer",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-09-13T00:00:01Z"
+        }
+    ]
+}


### PR DESCRIPTION
HEX:
0:551e764156dd15ac1e0465211b22e3d3a23649d30bbed657cb6f4d7b4df03aa5
Bounceable: EQBVHnZBVt0VrB4EZSEbIuPTojZJ0wu-1lfLb017TfA6pQVH
Non-bounceable: UQBVHnZBVt0VrB4EZSEbIuPTojZJ0wu-1lfLb017TfA6pViC

<img width="824" height="434" alt="Screenshot from 2025-09-13 07-42-17" src="https://github.com/user-attachments/assets/a27c2610-ea78-4e51-9d87-7ed778c94766" />

This address is used by ElephantStore to deploy NFT collections and also to receive Telegram stars cashout.

It recently created the Duckgram Stickers collection in collaboration with the Duckgram miniapp team:
<img width="1172" height="974" alt="image" src="https://github.com/user-attachments/assets/37e9a5b7-b5b1-4265-bc37-0c54339d8799" />
(https://t.me/duckygram_game/194)

The collection on Getgems:
<img width="543" height="548" alt="image" src="https://github.com/user-attachments/assets/11c6f131-ef12-4c31-94bb-ecc9f33b5326" />
(https://getgems.io/collection/EQB3S5LEOhcUTvq4ZpCcxKfx-8GgbQq4hutQSg8MNLu9PV9y)

It has also released other collections as collaborations with certain Telegram channels:
<img width="1829" height="475" alt="image" src="https://github.com/user-attachments/assets/47b38891-7895-454f-be72-ad24fbf88220" />


<img width="1159" height="971" alt="image" src="https://github.com/user-attachments/assets/8f21b704-e2b7-44e5-816d-04633800479b" />
(https://t.me/Wylsared/26775)

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0