### PR TITLE
add new starsgram label

### DIFF
--- a/assets/merchant/starsgram.json
+++ b/assets/merchant/starsgram.json
@@ -24,6 +24,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-08-31T17:00:02Z"
+        },
+         {
+            "address": "EQDvWbUQQZHKzXJrt4_AO03c38any9zoQRCyJrTQ2fCuT0TZ",
+            "source": "",
+            "comment": "Telegram Stars Cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-09-13T17:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:ef59b5104191cacd726bb78fc03b4ddcdfc6a7cbdce84110b226b4d0d9f0ae4f
Bounceable: EQDvWbUQQZHKzXJrt4_AO03c38any9zoQRCyJrTQ2fCuT0TZ
Non-bounceable: UQDvWbUQQZHKzXJrt4_AO03c38any9zoQRCyJrTQ2fCuTxkc

<img width="836" height="411" alt="Screenshot from 2025-09-13 22-21-48" src="https://github.com/user-attachments/assets/3824cf5a-1403-488c-9962-d897b6523003" />

This address is used by Starsgram to receive TON from Telegram Stars cashout and to fund their other wallets.

We first notice our address receives tokens from an already labelled starsgram address (an address typically used for user deposits):
<img width="1231" height="538" alt="image" src="https://github.com/user-attachments/assets/a128cd03-e97c-4ff5-8b00-88f756058e4b" />

Noting the point above, we can deduce that it is the starsgram team making these withdrawals.
Also, further analysis via Arkham has revealed huge outflows  of TON from the address we are labelling to two addresses (UQAptdWMknUvpWBSjqME98OCDIj43YybOYtyt5gX3o9SXzmd and UQA4t4xoi3h6tH8wAgwXi72-fX4oD46_ZLuX-oGbCZlOSwn9 ) :
<img width="964" height="163" alt="image" src="https://github.com/user-attachments/assets/209b663d-7f6d-4d3d-be50-102baf721cba" />

The first address (UQAptdWMknUvpWBSjqME98OCDIj43YybOYtyt5gX3o9SXzmd) owns the @starsgram collectible username which is used by the starsgram Telegram channel:
<img width="1207" height="674" alt="image" src="https://github.com/user-attachments/assets/56426672-61b3-4fb6-a1c6-e6c4cc97678b" />

<img width="416" height="535" alt="image" src="https://github.com/user-attachments/assets/2417586f-f329-4a30-89d2-11f2ccb7364c" />

The second address (UQA4t4xoi3h6tH8wAgwXi72-fX4oD46_ZLuX-oGbCZlOSwn9) owns the starsgram.ton TON DNS:
<img width="1241" height="666" alt="image" src="https://github.com/user-attachments/assets/0e989515-628f-4c51-acd1-45e107abd053" />

The transfer of these funds is then used to purchase Stars for Starsgram users.

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0