### PR TITLE
add new hypergift

### DIFF
--- a/assets/gaming/hypergift.json
+++ b/assets/gaming/hypergift.json
@@ -28,6 +28,14 @@
             ],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-08-31T00:00:01Z"
+        },
+        {
+            "address": "EQB0QZ3nKiSVRJCnxFOKeWaL9N_TeHGFOX0aAV6knMMh8r__",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-09-23T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:74419de72a24954490a7c4538a79668bf4dfd3787185397d1a015ea49cc321f2
Bounceable: EQB0QZ3nKiSVRJCnxFOKeWaL9N_TeHGFOX0aAV6knMMh8r__
Non-bounceable: UQB0QZ3nKiSVRJCnxFOKeWaL9N_TeHGFOX0aAV6knMMh8uI6

<img width="824" height="417" alt="Screenshot from 2025-09-23 11-13-45" src="https://github.com/user-attachments/assets/0af1f8c5-9797-4779-ae6b-149622acd649" />

This address receives the proceeds from Telegram Stars cashout and transfers it to two addresses (UQAvA8RbaSt1Vb4g2GBkSeKAtIvl9aiyCDQG8YObRUMFvVLp and UQCi4Yx_0ZJMO5KBTJg63JFUxXDaN_OipLFAJ0iqhqf-tjZw):

<img width="1200" height="729" alt="Screenshot from 2025-09-23 11-24-58" src="https://github.com/user-attachments/assets/30cbc919-a24d-4c56-bd33-600adec6068b" />

### First address involved
Tonviewer reveals that UQAvA8RbaSt1Vb4g2GBkSeKAtIvl9aiyCDQG8YObRUMFvVLp is a disposal address meaning it sends every token it receives to an exchange which is OKX in this case:

<img width="1200" height="729" alt="image" src="https://github.com/user-attachments/assets/8cce152c-9393-4faa-b7b9-02f9b614cdcc" />

Further analysis of transactions shows that UQB6_xW0bYy6qQuzxO6xpbzUCx6fd2tBpse_dC7xGqMJG99K the first address to interact with UQAvA8RbaSt1Vb4g2GBkSeKAtIvl9aiyCDQG8YObRUMFvVLp shows it receiving and then transferring the hypergift.ton domain NFT to an address UQA7KvaqHZUgJZHlShv4Ri_ylcPlLWk_vrjchwOcik3wxJiU which owns the @Hypergift collectible username:

<img width="1200" height="729" alt="Screenshot from 2025-09-23 12-11-34" src="https://github.com/user-attachments/assets/cd18a11f-1d9c-48d5-af0b-d159fe4de11f" />

<img width="1200" height="729" alt="image" src="https://github.com/user-attachments/assets/5b2765ed-0934-4690-94a5-76720afd6421" />

### 2nd address involved
Tonviewer reveals that UQDaG_OzkrcyRRrgsDYqTmUCQGYqBXSipAxwC_7vDeTaAsVW has once received 100 TON from an address already labelled as  hypergift:

<img width="1239" height="627" alt="image" src="https://github.com/user-attachments/assets/ef6ea824-11d2-4ddf-b080-967a82579f8a" />

Arkham reveals that this hypergift address has only a few outflows to other addresses:
<img width="960" height="725" alt="image" src="https://github.com/user-attachments/assets/aefe06c0-0f9a-4d25-bea9-21227c77c29a" />

Analysis of this outflows and other hypergift transactions shows that transactions done by users have a memo/comment in the style "GR_......" for either deposit or a payout:
<img width="1269" height="343" alt="image" src="https://github.com/user-attachments/assets/35320eaf-60d5-4917-8263-f47ded99ec66" />

Therefore it only makes sense that any outgoing transaction not using a memo belongs to hypergift themselves which makes means that UQDaG_OzkrcyRRrgsDYqTmUCQGYqBXSipAxwC_7vDeTaAsVW is a hypergift address. By extension, this further supplements the proof that the address we are labelling belongs to hypergift because of it's interaction with the above address:
<img width="1237" height="83" alt="Screenshot from 2025-09-23 16-54-50" src="https://github.com/user-attachments/assets/f174234d-a9e7-49b9-9dec-12df50eeae83" />


In conclusion, analysis of the address which interacted with the one we are labelling show a history with hypergift addresses that can only be conducted by Hypergift itself.

