### PR TITLE
add new ludogift

### DIFF
--- a/assets/gaming/ludogift.json
+++ b/assets/gaming/ludogift.json
@@ -23,6 +23,14 @@
             "tags": [],
             "submittedBy": "JackReachy",
             "submissionTimestamp": "2025-09-08T00:00:01Z"
+        },
+         {
+            "address": "EQA850_Qp1bwixBYHIYw0H1TaDX3MvMyYuXRZbBG6PJFBSIr",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-10-08T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:3ce74fd0a756f08b10581c8630d07d536835f732f33262e5d165b046e8f24505
Bounceable: EQA850_Qp1bwixBYHIYw0H1TaDX3MvMyYuXRZbBG6PJFBSIr
Non-bounceable: UQA850_Qp1bwixBYHIYw0H1TaDX3MvMyYuXRZbBG6PJFBX_u

<img width="1639" height="415" alt="Screenshot from 2025-10-08 13-53-33" src="https://github.com/user-attachments/assets/24329e5e-59b1-4c04-a22c-b708f8d4189a" />

This address most likely belongs to ludogift as we would see with the proofs below:
Opening the address in Tonviewer shows deposits of large amounts of TON from an already labelled ludogift address:
<img width="1380" height="906" alt="image" src="https://github.com/user-attachments/assets/ec4dfe83-da2e-4fc3-a50f-149dccafa4df" />

We can see it more clearly by opening the labelled address (UQB5WtKIzXu9P9EbEE2d-lxK4R_bjP3MB_hc0PfSFeOW7kXh) in Tonviewer:

<img width="1290" height="964" alt="image" src="https://github.com/user-attachments/assets/5a16de48-f56c-453c-97c7-fe7b7d3948bb" />

We can now see a recurring pattern: Fragment (Stars cashout) ==> UQB5WtKIzXu9P9EbEE2d-lxK4R_bjP3MB_hc0PfSFeOW7kXh (ludogift) ==> UQA850_Qp1bwixBYHIYw0H1TaDX3MvMyYuXRZbBG6PJFBX_u

Also, via Telegram we can see that the anonymous number owned by the address we are labelling is used by the owner of the Ludogift TG channel:

<img width="1115" height="738" alt="image" src="https://github.com/user-attachments/assets/9d99e2ab-a419-418a-8ce4-20a6774b73e8" />


<img width="399" height="803" alt="image" src="https://github.com/user-attachments/assets/9827794e-d0b9-4892-b340-870057b2b3ae" />


My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0