### PR TITLE
add p00ls address

### DIFF
--- a/assets/gaming/p00ls.json
+++ b/assets/gaming/p00ls.json
@@ -2,7 +2,7 @@
 	"metadata": {
 			"label": "p00ls",
 			"category": "gaming",
-			"subcategory": "",
+			"subcategory": "gambling",
 			"website": "https://t.me/p00ls_games_bot",
 			"description": "",
 			"organization": "p00ls"


### PR DESCRIPTION
HEX:
0:abd237331e55a01bb4be72a9f7d9373ab356747a1b13d37a14231be3bec38e00
Bonceable: EQCr0jczHlWgG7S-cqn32Tc6s1Z0ehsT03oUIxvjvsOOAA-m
Non-bounceable: UQCr0jczHlWgG7S-cqn32Tc6s1Z0ehsT03oUIxvjvsOOAFJj

<img width="772" height="406" alt="image" src="https://github.com/user-attachments/assets/45f0e903-b56d-4726-a17c-7d02242ef7fa" />

The P00LS Games project is related to the splash miniapp, we can ascertain this by visiting the splashapp_bot:
<img width="418" height="916" alt="image" src="https://github.com/user-attachments/assets/8b80333e-db12-4310-b1bf-3e81a4e94788" />
 On starting the bot we are immediately prompted to visit the P00LS Games miniapp.

On Tonviewer we notice recurring transactions from the address we are labelling to this address UQDOyWs9t4FuTiDVm_t5UnsXCEf4FQeL5um2SvVAPPKp2yBN. These transactions occur immediately after Telegram Stars cashout from Fragment :
<img width="1201" height="961" alt="image" src="https://github.com/user-attachments/assets/30fb2b43-72e5-4ba1-a1ee-bab5eb4e8103" />

Now this address UQDO.....2yBN is the deployer of the $SPLASH token;
<img width="1197" height="822" alt="Screenshot from 2025-10-14 06-22-27" src="https://github.com/user-attachments/assets/1fad8222-08f5-4d45-a13f-47482623ca9e" />

It also owns the following domains splash.ton, p00ls.ton and splashbot.ton which further solidifies it's relation to the two projects:
<img width="1215" height="875" alt="image" src="https://github.com/user-attachments/assets/29241bb8-ed68-4be0-936f-42ad6c578974" />

Analysis via Arkham shows that this address only interacts with a specific type of addresses i.e exchanges, smart contracts and others most likely belonging to the team. This means the transactions from the address we are labelling can't be related to users:
<img width="952" height="794" alt="image" src="https://github.com/user-attachments/assets/d27d251a-f2a0-44ec-a38b-81e4cf61626c" />

Lastly we can see a [transaction](https://tonviewer.com/transaction/062b584d3d3f84434dd1f9e8968e97b7562dea3b5668108cb611d9dc8649843d) from an already labelled splash address with the payload "POOLS - unclaimed tokens":
<img width="1249" height="94" alt="image" src="https://github.com/user-attachments/assets/b5a693db-6ecf-49e0-a625-5d4a17125641" />

I labelled this address under  a new p00ls projects because the splash miniapp redirects users to the p00ls miniapp. Therefore the p00ls miniapp can be seen as an extension of the splash miniapp.

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0