### PR TITLE
add new tonstation

### DIFF
--- a/assets/gaming/tonstation.json
+++ b/assets/gaming/tonstation.json
@@ -223,6 +223,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-09-12T00:00:01Z"
+        },
+        {
+            "address": "EQAezHrGQZF0JNlO4sGz_ILW1DiQMEZP45tPVcmqgnfpFt57",
+            "source": "",
+            "comment": "Telegram Stars Cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-10-15T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:1ecc7ac641917424d94ee2c1b3fc82d6d4389030464fe39b4f55c9aa8277e916
Bounceable: EQAezHrGQZF0JNlO4sGz_ILW1DiQMEZP45tPVcmqgnfpFt57
Non-bounceable: UQAezHrGQZF0JNlO4sGz_ILW1DiQMEZP45tPVcmqgnfpFoO-

<img width="752" height="407" alt="Screenshot from 2025-10-15 00-02-22" src="https://github.com/user-attachments/assets/f40c8b1f-e2fb-4d5e-9a01-44255b592e63" />

This is address is used by Tonstation to receive the proceeds of Telegram Stars cashout.
We can immediately see out first proof on Tonviewer. TON received as Stars cashout is immediately sent to an already labelled Tonstation address:
<img width="1242" height="548" alt="Screenshot from 2025-10-15 00-03-24" src="https://github.com/user-attachments/assets/146d3976-4ef4-4bfe-bdd4-76829010512d" />

Also scrolling to the first transactions on the address we are labelling, we can see a deposit to the Gate exchange using a memo "3462146552"

<img width="1217" height="180" alt="image" src="https://github.com/user-attachments/assets/f5d79b23-541c-44ea-a8cf-ea6b891e53aa" />

We can also see this memo used a number of times on an already labelled tonstation address:

<img width="1200" height="551" alt="image" src="https://github.com/user-attachments/assets/e88fa73c-498b-4d4f-a6e6-523fe7e3b5b2" />

Link to one of these transactions: https://tonviewer.com/transaction/f342e47118e6b40b54e6a362bb01d63adc0642e69b7b9ab231d868a1a162d73f