### PR TITLE
add new dropee

### DIFF
--- a/assets/gaming/dropee.json
+++ b/assets/gaming/dropee.json
@@ -31,6 +31,14 @@
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-02-11T00:00:01Z"
+        },
+        {
+            "address": "EQBRfW6HV0__ajQq58IE36mlMwPXw1-IvOXMRwUEGZZpkYfo",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-10-20T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:517d6e87574fff6a342ae7c204dfa9a53303d7c35f88bce5cc47050419966991
Bounceable: EQBRfW6HV0__ajQq58IE36mlMwPXw1-IvOXMRwUEGZZpkYfo
Non-bounceable: UQBRfW6HV0__ajQq58IE36mlMwPXw1-IvOXMRwUEGZZpkdot

<img width="807" height="412" alt="image" src="https://github.com/user-attachments/assets/7440eef7-03c6-42b0-a5c3-5a6a3e61b44c" />

This address is used to cashout Telegram Stars from the Dropee bot. 
First on Tonviewer we can immediately see some transactions with an already labelled Dropee address. The timing of these transactions is crucial as it occurs immediately the Telegram Stars cashout is received from Fragment:

<img width="1365" height="711" alt="image" src="https://github.com/user-attachments/assets/32e70725-07dd-4a82-a945-d6f667ee27c1" />

Inspecting this Dropee address shows that it us used for users USDT cashout as seen in withdrawals payloads:

<img width="1341" height="886" alt="image" src="https://github.com/user-attachments/assets/6ec998ca-4b12-4fe3-9ba6-9968035b32bd" />

We can also see that every TON deposit from the address we are labelling to this Dropee address is immediately swapped to USDT which is used as users withdrawals:

<img width="1326" height="87" alt="image" src="https://github.com/user-attachments/assets/6fe30499-40ea-47fd-9b9f-66236b7fa8c4" />

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0