### PR TITLE
Stars Wallet

### DIFF
--- a/assets/merchant/stars_wallet.json
+++ b/assets/merchant/stars_wallet.json
@@ -24,6 +24,14 @@
             "tags": [],
             "submittedBy": "turic24",
             "submissionTimestamp": "2025-09-13T17:00:02Z"
+        },
+        {
+            "address": "EQBfWg96wJZZkmrffsA4AV__YT_V2q80FbHn_TGyLt7qRgY_",
+            "source": "",
+            "comment": "Telegram stars cashout adress",
+            "tags": [],
+            "submittedBy": "turic24",
+            "submissionTimestamp": "2025-10-30T17:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:5f5a0f7ac09659926adf7ec038015fff613fd5daaf3415b1e7fd31b22edeea46
Bounceable: EQBfWg96wJZZkmrffsA4AV__YT_V2q80FbHn_TGyLt7qRgY_
Non-bounceable: UQBfWg96wJZZkmrffsA4AV__YT_V2q80FbHn_TGyLt7qRlv6

My-wallet: UQAbrZ8C6qUAgwfjZXLw54CabmmlL9Rnfem90yOPJ-fYBXbM

<img width="1622" height="463" alt="Screenshot_1" src="https://github.com/user-attachments/assets/e9e8dc5c-3ae7-49b1-a46e-0738398f1a20" />

This address belongs to the organization **Stars Wallet**

This wallet is completely filled with withdrawal transactions from Fragment to the address UQ...qVQxy, from which, in turn, all funds are withdrawn to the OKX exchange.

<img width="1101" height="745" alt="Screenshot_7" src="https://github.com/user-attachments/assets/80f56366-d27e-464c-9aeb-403af666a9d2" />

Let’s take a closer look at the address UQ...qVQxy…

First of all, if you move from the UQ...qVQxy wallet, all subsequent addresses demonstrate exactly the same behavioral pattern, which raises some thoughts.

My first attention was drawn to the top-up from the address UQ...nz9_j, where we can also notice an absolutely identical behavioral pattern.
https://tonviewer.com/transaction/0f251737ba406558c18e3477d501056222f605a66924870ec4b7022b31743709
UQ...nz9_j was sending its funds to UQ...ptls, which was in turn topped up with 150 TON solely from the Stars_wallet address, and later these funds were sent to the Binance exchange.
https://tonviewer.com/UQBBhJqAW2PwxMGBEn-v1tlqQy0iskfKmNq_G-FR8tscptls
https://tonviewer.com/transaction/44fe4a8518d173f38e53c912dd8834e16fe010f98ac1ba45618e6732132234b0

<img width="1108" height="381" alt="Screenshot_2" src="https://github.com/user-attachments/assets/fdee2a00-4ceb-4044-9292-acc4b9888a07" />

UQ...nz9_j also sent its funds to UQ...0GQhL, where a custodial wallet of the OKX exchange appears. This wallet is evidently used by Stars_Wallet for withdrawing its funds.
https://tonviewer.com/UQBnMbYKh9zj8STivHeGby_oV9Z2K_7FHPP9qVB-rYN0GQhL

<img width="1100" height="608" alt="Screenshot_3" src="https://github.com/user-attachments/assets/cd0fd736-152a-4483-bd96-8d0a231e6696" />

Let’s return to our address UQ...qVQxy. It was topped up from UQ...Py9w.
https://tonviewer.com/transaction/3f2d6855c994c1bf1633c4cd5a6428d877ae9c63b2cc7f7e02eb9aa3e47d5e5e

<img width="1325" height="748" alt="Screenshot_4" src="https://github.com/user-attachments/assets/9ff49ca9-fe6b-4786-a1eb-e177dc6ac50f" />

UQ...Py9w has been observed being used for the custodial wallet of Stars_wallet.
https://tonviewer.com/UQABTQRWnwFDaUArUNS2QEVVCQjOLZVZbTkR53vvqePI5FTd
https://tonviewer.com/transaction/323a44d6c695df03b42524c9b737df7595786dcc7c9d0161c2bbf94474e8f5cb

<img width="1139" height="699" alt="Screenshot_5" src="https://github.com/user-attachments/assets/a66e012b-5938-45a5-bf81-c63178d97242" />

The last and most significant piece of evidence: the address UQ...qVQxy received a TON transfer from UQ...NMC1. Then, UQ...NMC1 itself got its first top-up from UQ....BOK, which, in turn, repeats exactly the same pattern as the marked version of the Stars Wallet.
https://tonviewer.com/transaction/f0b42f117467b36a5fe0b750f5a3978dcbe04cee6f3041f425e75dd7724bfb23
https://tonviewer.com/transaction/58169248cc665739d8be48b7b11f619bac700ce9d5d5696e0a6a1f71c0aa6371
https://tonviewer.com/UQBG1Xp6JRX-j0DzzImtXR1vx7UoE1AK76KKO80LMXXFNMC1
https://tonviewer.com/UQDIDeYuG9Jh_39ZfO3zNx27JblIOUB8ZYr5jzHZ_1ckmBOK

<img width="1098" height="355" alt="Screenshot_6" src="https://github.com/user-attachments/assets/04f27bd4-4f7f-499c-905c-b8d00c553cbd" />
