### PR TITLE
add new gorilla_case

### DIFF
--- a/assets/gaming/gorilla_case.json
+++ b/assets/gaming/gorilla_case.json
@@ -15,6 +15,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-09-08T00:00:01Z"
+        },
+        {
+            "address": "EQC_kG7VATQprHVhMq_WRu92kxz7zo8W4uoZ5sl7iK5itemw",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-11-07T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:bf906ed5013429ac756132afd646ef76931cfbce8f16e2ea19e6c97b88ae62b5
Bounceable: EQC_kG7VATQprHVhMq_WRu92kxz7zo8W4uoZ5sl7iK5itemw
Non-bounceable: UQC_kG7VATQprHVhMq_WRu92kxz7zo8W4uoZ5sl7iK5itbR1

<img width="792" height="448" alt="Screenshot from 2025-11-07 05-52-02" src="https://github.com/user-attachments/assets/ab4caeda-4ac2-4238-9013-571a257f4ae5" />


This address belongs to Gorilla Case and is used to cashout Telegram Stars. Proofs;

Opening this address in Tonviewer immdiately reveals interactions with an already labelled Gorilla Case address:
<img width="1434" height="908" alt="image" src="https://github.com/user-attachments/assets/b1effe3a-fcd1-434a-b66d-c754e26659db" />

We can also notice a recurring pattern i.e TON received from Fragment is swapped to USDT and then some TON is sent to the gorilla_case address.

Observing this labelled gorilla_case address reveals that it is used for user deposits and each transaction uses a memo in the transaction payload:
<img width="1332" height="850" alt="image" src="https://github.com/user-attachments/assets/9837d363-cfad-46cf-be42-fa14fdaa70a3" />

These transactions allow us to rule out the possibility of user's deposits from the address we are labelling because it never uses a memo in it's transactions. 

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0