### PR TITLE
add new scammer address

### DIFF
--- a/assets/scammer/scammer.json
+++ b/assets/scammer/scammer.json
@@ -1092,6 +1092,14 @@
             "tags": [],
             "submittedBy": "turic24",
             "submissionTimestamp": "2025-10-30T01:01:01Z"
+        },
+        {
+            "address": "EQAIMP6alimmS-Q9g25H5R6nljMRFcQXvvaEM2YGqK4w7a9g",
+            "source": "",
+            "comment": "mexc-1.ton, mimics MEXC exchange",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-11-11T01:01:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:0830fe9a9629a64be43d836e47e51ea796331115c417bef684336606a8ae30ed
Bounceable: EQAIMP6alimmS-Q9g25H5R6nljMRFcQXvvaEM2YGqK4w7a9g
NOn-bounceable: UQAIMP6alimmS-Q9g25H5R6nljMRFcQXvvaEM2YGqK4w7fKl
DNS: mexc-1.ton

This address is already labelled as scam by Tonviewer:
<img width="615" height="318" alt="Screenshot from 2025-11-11 01-00-04" src="https://github.com/user-attachments/assets/fd2cde0e-e066-4afc-9212-501016707a4b" />
