### PR TITLE
add new stars_wallet

### DIFF
--- a/assets/merchant/stars_wallet.json
+++ b/assets/merchant/stars_wallet.json
@@ -40,6 +40,14 @@
             "tags": [],
             "submittedBy": "turic24",
             "submissionTimestamp": "2025-10-30T17:00:02Z"
+        },
+        {
+            "address": "EQCtpJSNL3z2GPBXbKQJFX19cU6WzmifXwYtha2n2g_oi0rO",
+            "source": "",
+            "comment": "Telegram stars cashout adress",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-11-11T17:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:ada4948d2f7cf618f0576ca409157d7d714e96ce689f5f062d85ada7da0fe88b
Bounceable: EQCtpJSNL3z2GPBXbKQJFX19cU6WzmifXwYtha2n2g_oi0rO
Non-bounceable: UQCtpJSNL3z2GPBXbKQJFX19cU6WzmifXwYtha2n2g_oixcL

<img width="625" height="440" alt="Screenshot from 2025-11-11 01-58-25" src="https://github.com/user-attachments/assets/797538c2-4054-4bf0-b404-c280c6df2216" />


This address receives Telegram Stars cashout and then proceeds to send it to UQBKtKu5KzQF4UTckNPNxcEU0xQ7YF1bWHLkeozMhXjqVQxy. This recipient address seems to be an OKX user deposit address because every deposit is immediately sent to the OKX exchange:
<img width="1287" height="664" alt="image" src="https://github.com/user-attachments/assets/e010d0e9-fca7-455d-bc07-61b2a55fa312" />

Taking a look at UQBK...Qxy we can observe similar transactions of this exact nature with already labelled Stars Wallet address i.e TON is received from Fragment, sent to OKX user deposit address and then finally sent to OKX:
<img width="1287" height="664" alt="image" src="https://github.com/user-attachments/assets/fb600af0-4e48-44b0-b89d-3560598d86bc" />

The fact that the address we are labelling interacts solely with an OKX user deposit address used by Stars Wallet can only mean it also  belongs to Stars Wallet.

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0