### PR TITLE
add new 1case

### DIFF
--- a/assets/gaming/1case.json
+++ b/assets/gaming/1case.json
@@ -23,6 +23,14 @@
             "tags": [],
             "submittedBy": "turic24",
             "submissionTimestamp": "2025-10-30T00:00:01Z"
+        },
+        {
+            "address": "EQAedaQe-0-ecr6LB8QcXRRkYntKsG6bqSI-4v3eXCzF7gy-",
+            "source": "",
+            "comment": "Telegram stars cashout adress",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2025-11-28T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:1e75a41efb4f9e72be8b07c41c5d1464627b4ab06e9ba9223ee2fdde5c2cc5ee
Bounceable: EQAedaQe-0-ecr6LB8QcXRRkYntKsG6bqSI-4v3eXCzF7gy-
Non-bounceable: UQAedaQe-0-ecr6LB8QcXRRkYntKsG6bqSI-4v3eXCzF7lF7

<img width="796" height="440" alt="Screenshot from 2025-11-28 07-31-18" src="https://github.com/user-attachments/assets/05455816-432f-4ec2-9622-ee8bb83814e5" />

Opening this address on Tonviewer shows deposits from an already labelled 1case address:
<img width="1191" height="628" alt="image" src="https://github.com/user-attachments/assets/0524c287-12fd-4f06-88e5-65d92703a64e" />

Analysis of this 1case address reveals it is used solely for user deposits:
<img width="1217" height="888" alt="image" src="https://github.com/user-attachments/assets/15eb048b-8fe3-479b-8f70-ceb5a18e4c95" />

Arkham also shows very few withdrawals from this 1case address but a with a large amont of volume to the address we are labelling:
<img width="971" height="753" alt="Screenshot from 2025-11-28 07-35-01" src="https://github.com/user-attachments/assets/a3bf537a-fa58-4836-a90b-698011c7045f" />

Therefore we can conclude that the deposits from 1case to the address we are labelling is from 1case itself.

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0