### PR TITLE
Add goldsticker

### DIFF
--- a/assets/gaming/goldsticker.json
+++ b/assets/gaming/goldsticker.json
@@ -22,7 +22,7 @@
             "comment": "Telegram stars cashout address",
             "tags": [],
             "submittedBy": "EF-Code",
-            "submissionTimestamp": "2025-05-23T00:00:01Z"
+            "submissionTimestamp": "2025-12-12T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:4ad4ecdcc58708725f319f0fdcfd831816ef84bf261faba6018c797ae7ef11ec
Bounceable: EQBK1OzcxYcIcl8xnw_c_YMYFu-EvyYfq6YBjHl65-8R7HlM
Non-bounceable: UQBK1OzcxYcIcl8xnw_c_YMYFu-EvyYfq6YBjHl65-8R7CSJ

<img width="788" height="418" alt="Screenshot from 2025-12-12 13-33-23" src="https://github.com/user-attachments/assets/d497ab01-be98-4734-8b38-94711ab55831" />

Analysis of inbound and outound volume of this address VIA Arkham reveals huge deposits to these addresses UQB6Qrru_1YhTe1qwiRVJ_tWnK_si3vTRTw2CX1uQxFi2s2P and UQBU1RrntlESBcBaGlQOTSF6X0BsDXl7yXtOCIUAQUAkXccK :
<img width="972" height="297" alt="image" src="https://github.com/user-attachments/assets/9eacfe1a-b4df-4562-ab21-4bfd72e629e5" />

Viewing the first address UQB6Q.......Fi2s2P on Tonviewer reveals withdrawals to an already labelled Goldsticker address with certain comments (payloads):
<img width="1213" height="658" alt="image" src="https://github.com/user-attachments/assets/5d4ac629-1f1f-4af9-9f98-21db6eee3a44" />

These transactions as indicated by their comments are used to supply the main Goldsticker address with user rewards.

We can also see transactions with certain comments from UQB6Q.......Fi2s2P to the address we are labelling:
<img width="1220" height="128" alt="image" src="https://github.com/user-attachments/assets/6b70494e-258b-41fd-a8cf-a67bb9951683" />

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0

