### PR TITLE
Add ton place

### DIFF
--- a/assets/merchant/ton_place.json
+++ b/assets/merchant/ton_place.json
@@ -44,7 +44,7 @@
          {
             "address": "EQDHBNrfq6yI6rWONA3gMIDfgf92Y2Qx9IYkrW4m-y2gpN5V",
             "source": "",
-            "comment": "Telegram Stars cashout address.",
+            "comment": "",
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-12-25T00:00:01Z"


### PR DESCRIPTION
HEX:
0:c704dadfabac88eab58e340de03080df81ff76636431f48624ad6e26fb2da0a4
Non-bounceable: EQDHBNrfq6yI6rWONA3gMIDfgf92Y2Qx9IYkrW4m-y2gpN5V
Bounceable: UQDHBNrfq6yI6rWONA3gMIDfgf92Y2Qx9IYkrW4m-y2gpIOQ

<img width="1619" height="439" alt="image" src="https://github.com/user-attachments/assets/dff31f59-75ab-4cd1-a6c4-ee6fab9bd2b5" />

Viewing this address on Tonviewer, we can see it's most recent legitimate transaction was to UQBVPeKZyRj1r7Fld7-GzcR0vxCHyYUcnFNaj0Csu6T-k_6J:
<img width="1559" height="498" alt="image" src="https://github.com/user-attachments/assets/19ae91bc-4715-4f69-b4f6-525e2185480b" />

Now UQBVP.......T-k_6J is a Bybit deposit address which has previously received tokens from an already labelled ton_place address and also from place.ton:
<img width="1583" height="867" alt="image" src="https://github.com/user-attachments/assets/6dc8674c-c35c-4791-8a3b-e3d0d6608c33" />

Via Arkham, we can see the largest volume of withdrawals from the address we are labelling was to another ton_place address :
<img width="968" height="187" alt="image" src="https://github.com/user-attachments/assets/50f61785-a566-4518-9a96-3602ebd95e02" />

This ton_place address in question here (UQDI_6jJaNNjbPIppoW9HNLe63YAndVGRufU_bEkPzujMLGp), i believe it was previously used as a withdrawal address for users:
<img width="1451" height="808" alt="image" src="https://github.com/user-attachments/assets/f1f0d5f5-a3c0-4f6e-ab85-116ce558c6c0" />

These transactions highlighted above especially the one involving the Bybit deposit address, directly ties our address to ton_place.

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0