### PR TITLE
add new stars_wallet

### DIFF
--- a/assets/merchant/rocket_star_finance.json
+++ b/assets/merchant/rocket_star_finance.json
@@ -16,14 +16,6 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-11-28T17:00:02Z"
-       },
-       {
-            "address": "EQAbbwx_c-O7Eg6DKIvMAKspV__zzQF0VKqLN0QqL1jnz4Im",
-            "source": "",
-            "comment": "Telegram Stars Cashout address.",
-            "tags": [],
-            "submittedBy": "ef-code",
-            "submissionTimestamp": "2026-01-15T17:00:02Z"
        }
     ]
 }

--- a/assets/merchant/stars_wallet.json
+++ b/assets/merchant/stars_wallet.json
@@ -48,6 +48,14 @@
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-11-11T17:00:02Z"
-        }
+        },
+       {
+            "address": "EQAbbwx_c-O7Eg6DKIvMAKspV__zzQF0VKqLN0QqL1jnz4Im",
+            "source": "",
+            "comment": "Telegram Stars Cashout address. Probably affiliated with RocketStars and others.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-01-15T17:00:02Z"
+       }
     ]
 }


### PR DESCRIPTION
HEX:
0:1b6f0c7f73e3bb120e83288bcc00ab2957fff3cd017454aa8b37442a2f58e7cf
Bounceable: EQAbbwx_c-O7Eg6DKIvMAKspV__zzQF0VKqLN0QqL1jnz4Im
Non-bounceable: UQAbbwx_c-O7Eg6DKIvMAKspV__zzQF0VKqLN0QqL1jnz9_j

<img width="789" height="446" alt="Screenshot_2026-01-15_18-10-11" src="https://github.com/user-attachments/assets/f409a503-47b1-4d9e-a977-d5003ee49e9d" />

Via Tonviewer, we can see numerous transactions to UQABTQRWnwFDaUArUNS2QEVVCQjOLZVZbTkR53vvqePI5FTd which usually occur after withdrawal of Telegram Stars: 
<img width="1231" height="534" alt="Screenshot_2026-01-15_18-10-51" src="https://github.com/user-attachments/assets/8bd6126d-7c4a-43d5-9596-a95a272ca721" />

UQABTQRWnwFDaUArUNS2QEVVCQjOLZVZbTkR53vvqePI5FTd seems to be an OKX deposit address. It has also received multiple deposits from addresses labelled as stars_wallet and rocket_star_finance:
<img width="1300" height="670" alt="Screenshot_2026-01-15_18-14-44" src="https://github.com/user-attachments/assets/e8d65164-48ff-4872-a88c-c68a2792283c" />

The stars_wallet bot which doesn't seem to be active again mentions rocket_star_finance in it's about info, so i believe it is logical to label this address as rocket_star_finance :
<img width="390" height="435" alt="Screenshot_2026-01-15_18-29-41" src="https://github.com/user-attachments/assets/5467ed9c-c896-4283-a6d2-e370699d5f83" />

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0