### PR TITLE
add new labubu_stars

### DIFF
--- a/assets/merchant/labubu_star.json
+++ b/assets/merchant/labubu_star.json
@@ -16,6 +16,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-08-19T17:00:02Z"
+        },
+        {
+            "address": "EQD-FuDEfdFL90K8fv5MWm60GBErNQY_ZRO-PlMYsLdzSpcC",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-01-26T17:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:fe16e0c47dd14bf742bc7efe4c5a6eb418112b35063f6513be3e5318b0b7734a
Non-bounceable: EQD-FuDEfdFL90K8fv5MWm60GBErNQY_ZRO-PlMYsLdzSpcC
Bounceable: UQD-FuDEfdFL90K8fv5MWm60GBErNQY_ZRO-PlMYsLdzSsrH

<img width="804" height="434" alt="Screenshot_2026-01-26_20-23-41" src="https://github.com/user-attachments/assets/6691ead0-1a45-4153-bea4-54ff2df163b2" />

From the bot's description, we can see the project's channel name @labubustarz:
<img width="538" height="473" alt="Screenshot_2026-01-26_20-19-23" src="https://github.com/user-attachments/assets/1e1e1232-7bf6-4930-b5a4-ff79a76246c1" />

This address recently placed a bid on Fragment to mint this username onchain:
<img width="1350" height="165" alt="Screenshot_2026-01-26_20-19-35" src="https://github.com/user-attachments/assets/8a1c203c-4c16-4299-8004-7ae3ca0b4530" />

Also, we can see a recent deposit to an address labelled as labubu_starz without any payload (comment):
<img width="1281" height="105" alt="Screenshot_2026-01-26_20-21-35" src="https://github.com/user-attachments/assets/f83227b8-41d0-45f2-8f5f-5b43ec7b4862" />

Now user deposits to the labubu_starz address always includes a memo but the above transaction indicates otherwise:
<img width="437" height="962" alt="Screenshot_2026-01-26_20-21-00" src="https://github.com/user-attachments/assets/32e28afe-d97a-4aa1-a81a-0b7e2884f749" />

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0