### PR TITLE
add new virus address

### DIFF
--- a/assets/gaming/virus.json
+++ b/assets/gaming/virus.json
@@ -40,6 +40,14 @@
       "tags": [],
       "submittedBy": "arbuz321",
       "submissionTimestamp": "2025-09-14T00:00:01Z"
+    },
+    {
+      "address": "EQAQ_aksgdk8JG9iNPi_6Dfy9d6s_wQwqbOA7GjTxxeOqgsz",
+      "source": "",
+      "comment": "Telegram Stars cashout address.",
+      "tags": [],
+      "submittedBy": "ef-code",
+      "submissionTimestamp": "2026-01-28T00:00:01Z"
     }
   ]
 }


### PR DESCRIPTION
HEX:
0:10fda92c81d93c246f6234f8bfe837f2f5deacff0430a9b380ec68d3c7178eaa
Non-bounceable: EQAQ_aksgdk8JG9iNPi_6Dfy9d6s_wQwqbOA7GjTxxeOqgsz
Bounceable: UQAQ_aksgdk8JG9iNPi_6Dfy9d6s_wQwqbOA7GjTxxeOqlb2

<img width="796" height="431" alt="Screenshot_2026-01-28_02-01-34" src="https://github.com/user-attachments/assets/3204040f-9085-4d00-a501-7806bb155962" />

This address has only interacted with UQA8MjSPgdDVisE2l6pqZNzcsVPQk7j9l9JFyNLKcEQZKDse:
<img width="1305" height="368" alt="Screenshot_2026-01-28_02-04-21" src="https://github.com/user-attachments/assets/6d11639a-60c9-4245-9605-a122494fe0bf" />

UQA8MjSPgdDVisE2l6pqZNzcsVPQk7j9l9JFyNLKcEQZKDse appears to be a Binance deposit address and it is being used by an already labelled virus TG stars withdrawal address:
<img width="1261" height="728" alt="Screenshot_2026-01-28_02-05-50" src="https://github.com/user-attachments/assets/6cb21eb9-7c4a-4d98-8774-2ab6a0787b0b" />

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0