### PR TITLE
add new helperstars

### DIFF
--- a/assets/merchant/helperstars.json
+++ b/assets/merchant/helperstars.json
@@ -40,6 +40,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2026-01-05T17:00:02Z"
+        },
+        {
+            "address": "EQB3ZPNZWW-j8WDfuSS7GbrXVrCrTgLrsFRVh-eKzT84fw0X",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-01-30T17:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:7764f359596fa3f160dfb924bb19bad756b0ab4e02ebb0545587e78acd3f387f
NOn-bounceable: EQB3ZPNZWW-j8WDfuSS7GbrXVrCrTgLrsFRVh-eKzT84fw0X
Bounceable: UQB3ZPNZWW-j8WDfuSS7GbrXVrCrTgLrsFRVh-eKzT84f1DS

<img width="792" height="453" alt="Screenshot_2026-01-30_19-57-07" src="https://github.com/user-attachments/assets/f7dd0f9b-9e29-4f98-9fda-43184f7c7fb9" />

This address deposits the entirety of Telegram Stars proceeds to helperstars.ton:
<img width="1412" height="515" alt="Screenshot_2026-01-30_19-59-23" src="https://github.com/user-attachments/assets/542c1e88-241c-4723-a592-39c32788aa65" />

helperstars.ton is the deposit address indicated in the Telegram bot:
<img width="560" height="975" alt="Screenshot_2026-01-30_19-50-31" src="https://github.com/user-attachments/assets/1314bef0-81ce-4c48-bea8-2e455d7819f3" />

We can also find large transactions from the address we are labelling to already labelled helperstars address:
<img width="1377" height="656" alt="Screenshot_2026-01-30_20-01-17" src="https://github.com/user-attachments/assets/f6b55e42-1c9d-4854-84c3-5718b6f521ec" />

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0