### PR TITLE
Create dickshoti.json

### DIFF
--- a/assets/gaming/dickshoti.json
+++ b/assets/gaming/dickshoti.json
@@ -1,0 +1,20 @@
+{
+    "metadata": {
+        "label": "dickshoti",
+        "category": "gaming",
+        "subcategory": "",
+        "website": "https://t.me/dickshotibot",
+        "description": "",
+        "organization": "dickshoti"
+    },
+    "addresses": [
+        {
+            "address": "EQCy-Mwro4u7XxwGFKlBbygPRi2rvCLN8byu6R4wHLt9nwua",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-02-12T00:00:01Z"
+        }
+    ]
+}


### PR DESCRIPTION
HEX:
0:b2f8cc2ba38bbb5f1c0614a9416f280f462dabbc22cdf1bcaee91e301cbb7d9f
Non-bounceable: EQCy-Mwro4u7XxwGFKlBbygPRi2rvCLN8byu6R4wHLt9nwua
Bonceable: UQCy-Mwro4u7XxwGFKlBbygPRi2rvCLN8byu6R4wHLt9n1Zf

<img width="1616" height="449" alt="image" src="https://github.com/user-attachments/assets/2ca672aa-ac4e-451b-9db8-3d084477155f" />

This address has been conducting an "airdrop" of a $DICKSHOTI token to numerous wallets with the payload explicitly mentioning @dickshotibot:
<img width="1499" height="712" alt="image" src="https://github.com/user-attachments/assets/1cfae087-f15f-49dd-ab97-89a4e3257345" />

The @dickshoti channel had made an announcement of this event early on along with a video of it's miniapp:
<img width="1180" height="899" alt="image" src="https://github.com/user-attachments/assets/1f8c0e6b-5767-48f4-b6fc-378bf47e3c5e" />

This address was also funded by dickshoti.ton and mavrody.ton:
<img width="1347" height="93" alt="image" src="https://github.com/user-attachments/assets/e9367093-8a26-4d16-90b2-3581db0a7238" />

The owner of the project's group with the username @rootaccess also owns the mavrody.ton domain:
<img width="1648" height="1002" alt="image" src="https://github.com/user-attachments/assets/9cc9b19a-1199-4e13-ba6f-7a6150c2e859" />

<img width="793" height="553" alt="image" src="https://github.com/user-attachments/assets/366f9d3a-966c-423b-a110-1ef2513de5a2" />


The miniapp doesn't seem to be working right now though.

My address: UQDWLVQ2hW5tiJ428hluAf_UbTLNp76FlOEJyiKofltD06U0