### PR TITLE
add new virus

### DIFF
--- a/assets/gaming/virus.json
+++ b/assets/gaming/virus.json
@@ -48,6 +48,14 @@
       "tags": [],
       "submittedBy": "ef-code",
       "submissionTimestamp": "2026-01-28T00:00:01Z"
+    },
+    {
+      "address": "EQAdMsVURc03_MbFKdwK_JUl5S3h41yqDJdZNQd-jp68wg5-",
+      "source": "",
+      "comment": "Telegram Stars cashout address.",
+      "tags": [],
+      "submittedBy": "ef-code",
+      "submissionTimestamp": "2026-03-29T00:00:01Z"
     }
   ]
 }


### PR DESCRIPTION
HEX:
0:1d32c55445cd37fcc6c529dc0afc9525e52de1e35caa0c975935077e8e9ebcc2
Non-bounceable: EQAdMsVURc03_MbFKdwK_JUl5S3h41yqDJdZNQd-jp68wg5-
Bounceable: UQAdMsVURc03_MbFKdwK_JUl5S3h41yqDJdZNQd-jp68wlO7

<img width="806" height="440" alt="image" src="https://github.com/user-attachments/assets/4b6187a6-306b-425c-825d-35849cb71df1" />

This address upon receiving the proceeds of Telegram Stars cashout, proceeded to deposit it to a Binance deposit address UQA8MjSPgdDVisE2l6pqZNzcsVPQk7j9l9JFyNLKcEQZKDse:
<img width="1203" height="735" alt="image" src="https://github.com/user-attachments/assets/e28decad-dd5f-4406-aa35-9ca6f3ec1e1a" />

<img width="1211" height="690" alt="image" src="https://github.com/user-attachments/assets/079735ed-594f-4efe-946f-f9deb3a35833" />

This Binance deposit has previously been used by an already labelled virus address:
<img width="1211" height="690" alt="image" src="https://github.com/user-attachments/assets/560f8d8f-84de-4321-afe7-d20496f248ef" />
