### PR TITLE
add new scammer address

### DIFF
--- a/assets/scammer/scammer.json
+++ b/assets/scammer/scammer.json
@@ -1133,6 +1133,17 @@
             ],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2026-03-03T00:00:01Z"
+        },
+        {
+            "address": "EQDUfvzQfBIAXGqon4BGwoXmbHlUbX3grc6TMxz0rz-yvamj",
+            "source": "",
+            "comment": "",
+            "tags": [
+                "scammer",
+                "suspicious"
+            ],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-03-30T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:d47efcd07c12005c6aa89f8046c285e66c79546d7de0adce93331cf4af3fb2bd
Non-bounceable: EQDUfvzQfBIAXGqon4BGwoXmbHlUbX3grc6TMxz0rz-yvamj
Bounceable: UQDUfvzQfBIAXGqon4BGwoXmbHlUbX3grc6TMxz0rz-yvfRm

Via Arkham Intelligence, we see that this address has received tokens from UQDBlp-robRY_CnjtfDMgXvsm-3XZQ6s69tAW-N3SwGsvO8q:
<img width="959" height="272" alt="image" src="https://github.com/user-attachments/assets/1c4268d8-5dad-4703-b339-5900fe0f2f73" />

UQDBlp-robRY_CnjtfDMgXvsm-3XZQ6s69tAW-N3SwGsvO8q has received multiple deposits from UQBycYdkJiv23naHUzxTSu2I87HtNOMXiZ-ND67R8As017ed. This UQBy....17ed address in turn received it's deposits from an already labelled scammer address among other:
<img width="1232" height="854" alt="image" src="https://github.com/user-attachments/assets/2abd1ef2-7bab-41da-9af0-e6ee0ae52832" />

<img width="1229" height="824" alt="image" src="https://github.com/user-attachments/assets/e2ac8019-d471-4c9f-aee2-9fe5fc40598a" />
