### PR TITLE
add new spins address

### DIFF
--- a/assets/gaming/spins.json
+++ b/assets/gaming/spins.json
@@ -19,7 +19,7 @@
         {
             "address": "EQCi6XjVYLOKUvGglHAkDs8rX6r6fOrU0_gjSIbPKLzYoSlk",
             "source": "",
-            "comment": "Telegram Stars cashout address",
+            "comment": "Possible Telegram Stars cashout from https://t.me/duels",
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2026-04-10T00:00:01Z"

--- a/assets/gaming/spins.json
+++ b/assets/gaming/spins.json
@@ -15,6 +15,14 @@
             "tags": [],
             "submittedBy": "turic24",
             "submissionTimestamp": "2025-09-13T00:00:01Z"
+        },
+        {
+            "address": "EQCi6XjVYLOKUvGglHAkDs8rX6r6fOrU0_gjSIbPKLzYoSlk",
+            "source": "",
+            "comment": "Telegram Stars cashout address",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-04-10T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:a2e978d560b38a52f1a09470240ecf2b5faafa7cead4d3f8234886cf28bcd8a1
Non-bounceable: EQCi6XjVYLOKUvGglHAkDs8rX6r6fOrU0_gjSIbPKLzYoSlk
Bounceable: UQCi6XjVYLOKUvGglHAkDs8rX6r6fOrU0_gjSIbPKLzYoXSh

<img width="799" height="453" alt="Screenshot From 2026-04-10 16-31-49" src="https://github.com/user-attachments/assets/c77aecbd-fae6-4f58-920b-89d778c359b6" />


Via Tonviewer, we can observe that this address has frequently interacted with an address with the DNS domain cool.ton including transferring an NFT bought for 20,000 TON:

<img width="1209" height="803" alt="image" src="https://github.com/user-attachments/assets/2a3fbfff-d434-4bcb-96e3-fa75e7c8f787" />

cool.ton owns the @spins and @wins collectible usernames:
<img width="1209" height="803" alt="image" src="https://github.com/user-attachments/assets/b70a7f0a-968e-4782-88db-e720086d0ebe" />

Meanwhile the address we are labelling owns the @win_support collectible username which it received from cool.ton:
<img width="1206" height="617" alt="image" src="https://github.com/user-attachments/assets/d1ac936f-7d3e-4d67-a75e-363fc0bf9683" />

@win_support on Telegram:
<img width="387" height="355" alt="Screenshot From 2026-04-10 16-29-19" src="https://github.com/user-attachments/assets/701231b8-26c2-49a9-95c9-d4b7738f5d9a" />
