### PR TITLE
add new giftup address

### DIFF
--- a/assets/gaming/giftup.json
+++ b/assets/gaming/giftup.json
@@ -28,6 +28,14 @@
             ],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-11-28T00:00:01Z"
+        },
+        {
+            "address": "EQBseU2o2008hJpvSnlRex9zI48rvO83zuUQkzWXcQYJpchK",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-04-22T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:6c794da8db4d3c849a6f4a79517b1f73238f2bbcef37cee510933597710609a5
Non-bounceable: EQBseU2o2008hJpvSnlRex9zI48rvO83zuUQkzWXcQYJpchK
Bounceable: UQBseU2o2008hJpvSnlRex9zI48rvO83zuUQkzWXcQYJpZWP

<img width="798" height="485" alt="Screenshot From 2026-04-22 22-41-38" src="https://github.com/user-attachments/assets/be862d28-5977-4313-b496-397444f94307" />

This address has interacted with just a single other address ever which is an already labelled Giftup address (UQAVl-kNca_8lY76kp672DpjPLoZJN7mw8v1SL8PMe4a5jY7). It conducts immediate transfer of TON received from Telegram Stars cashout to to the Giftup address.:
<img width="1203" height="689" alt="image" src="https://github.com/user-attachments/assets/ba8c2bf9-12a8-4982-b7ed-0039f37adb27" />

This GIftup address appears to be the primary user deposit address, each user with their individual memo for deposits. However, transactions from the address we are labelling never make use of a memo which allows to discard any notion of user deposits and attribute the transactions to the team:
<img width="1247" height="681" alt="Screenshot From 2026-04-22 22-50-10" src="https://github.com/user-attachments/assets/aa02cfb9-5175-4958-bcdf-79a8d761b538" />

