### PR TITLE
Create stars_mint.json

### DIFF
--- a/assets/merchant/stars_mint.json
+++ b/assets/merchant/stars_mint.json
@@ -2,7 +2,7 @@
     "metadata": {
         "label": "stars_mint",
         "name": "Stars Mint",
-        "organization": "thelabs",
+        "organization": "laba",
         "category": "merchant",
         "subcategory": "",
         "description": "TG Stars marketplace. Affiliated with Starsly",

--- a/assets/merchant/stars_mint.json
+++ b/assets/merchant/stars_mint.json
@@ -2,7 +2,7 @@
     "metadata": {
         "label": "stars_mint",
         "name": "Stars Mint",
-        "organization": "Labs",
+        "organization": "thelabs",
         "category": "merchant",
         "subcategory": "",
         "description": "TG Stars marketplace. Affiliated with Starsly",

--- a/assets/merchant/stars_mint.json
+++ b/assets/merchant/stars_mint.json
@@ -1,0 +1,21 @@
+{
+    "metadata": {
+        "label": "stars_mint",
+        "name": "Stars Mint",
+        "organization": "Labs",
+        "category": "merchant",
+        "subcategory": "",
+        "description": "TG Stars marketplace. Affiliated with Starsly",
+        "website": "https://t.me/stars_mint_bot"
+    },
+    "addresses": [
+        {
+      "address": "EQBWIloxNocComDiBwhwudaI8nEB1ss02oe1b2X03y3P9T0i",
+      "source": "",
+      "comment": "Telegram Stars cashout address. Also funds https://t.me/StarsllyBot",
+      "tags": [],
+      "submittedBy": "ef-code",
+      "submissionTimestamp": "2026-04-23T00:00:01Z"
+    }
+    ]
+}

--- a/assets/merchant/starsly.json
+++ b/assets/merchant/starsly.json
@@ -16,14 +16,7 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-12-10T17:00:02Z"
-        },
-    {
-      "address": "EQBWIloxNocComDiBwhwudaI8nEB1ss02oe1b2X03y3P9T0i",
-      "source": "",
-      "comment": "Telegram Stars cashout address.",
-      "tags": [],
-      "submittedBy": "ef-code",
-      "submissionTimestamp": "2026-04-23T00:00:01Z"
-    }
+        }
+    
     ]
 }

--- a/assets/merchant/starsly.json
+++ b/assets/merchant/starsly.json
@@ -16,6 +16,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-12-10T17:00:02Z"
-        }
+        },
+    {
+      "address": "EQBWIloxNocComDiBwhwudaI8nEB1ss02oe1b2X03y3P9T0i",
+      "source": "",
+      "comment": "Telegram Stars cashout address.",
+      "tags": [],
+      "submittedBy": "ef-code",
+      "submissionTimestamp": "2026-04-23T00:00:01Z"
+    }
     ]
 }


### PR DESCRIPTION
Hex:
0:56225a31368702a260e2070870b9d688f27101d6cb34da87b56f65f4df2dcff5
Non-bounceable: EQBWIloxNocComDiBwhwudaI8nEB1ss02oe1b2X03y3P9T0i
Bounceable: UQBWIloxNocComDiBwhwudaI8nEB1ss02oe1b2X03y3P9WDn

<img width="805" height="476" alt="Screenshot From 2026-04-22 23-22-10" src="https://github.com/user-attachments/assets/92f1cc12-7462-42de-ab31-62eaf4704aed" />

This address has only ever interacted with two other addresses, UQAbnn45XdUsNMqACY76faV8h5TAn-6JyMXi8ao8UpIWLVYm and UQAraqPdhswHKSwQoXMuRNq9QhrsUYS3J4_Xc5EawDiXIVdk:
<img width="1176" height="175" alt="image" src="https://github.com/user-attachments/assets/1deb8f53-dd2a-44ee-af75-f5d2655e6ec3" />

Checking out any of the two address, we can see USDT deposits from a starsly labelled address which is then swapped and used to purchase Telegram Stars for users:
<img width="1241" height="413" alt="image" src="https://github.com/user-attachments/assets/7d8d494c-bcc2-4bb7-b685-7572fc6eff7b" />

<img width="1247" height="508" alt="image" src="https://github.com/user-attachments/assets/7dde6b4a-f01e-439c-a688-1aa1e6b9176e" />

Via Arkham, we can see that these two address are the largest recipients of the outflow from the starsly address with UQAbnn45XdUsNMqACY76faV8h5TAn-6JyMXi8ao8UpIWLVYm appearing to be the active one for users Telegram Stars purchases:
<img width="967" height="205" alt="image" src="https://github.com/user-attachments/assets/a9649c9d-6b9f-4055-8329-56c078e1f5cc" />


