### PR TITLE
fund/ton_ecosystem_reserve: add validator operator wallet

### DIFF
--- a/assets/fund/ton_ecosystem_reserve.json
+++ b/assets/fund/ton_ecosystem_reserve.json
@@ -31,6 +31,14 @@
             "tags": [],
             "submittedBy": "markysha",
             "submissionTimestamp": "2025-12-01T00:00:01Z"
+        },
+        {
+            "address": "EQC13ey5YsjSTFhuB3LpEfzXbo0JPMEgyhzNVQSW7fjC1elW",
+            "source": "ton-foundation",
+            "comment": "Operator wallet — deploys/funds 8 TON Foundation mainnet validators since 2026-04-15",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2026-04-28T00:00:00Z"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds `EQC13ey5YsjSTFhuB3LpEfzXbo0JPMEgyhzNVQSW7fjC1elW` (raw `0:B5DDECB962C8D24C586E0772E911FCD76E8D093CC120CA1CCD550496EDF8C2D5`) to `assets/fund/ton_ecosystem_reserve.json`.

This basechain wallet operates as the deployer/funder for 8 TON Foundation mainnet validators that came online on 2026-04-15. Each validator was funded indirectly: the operator wallet sent ~202 TON to 8 intermediate masterchain wallets, which in turn deployed the validator contracts now staking with the system elector.

## Why this label matters

In the [TON Foundation staking dashboard](https://dune.com/ton_foundation/staking), pool entities are resolved by walking the `first_tx_sender` chain (pool → inviter → inviter_of_inviter) and picking the first labeled hop. All 8 validators currently fall back to an anonymous `group 0:B5D..C2D5` row because none of the wallets in the chain are labeled. Adding this single deployer label causes the entity resolver to attribute all 8 validators (≈15M TON in stake) to `ton_ecosystem_reserve`.

## Verification

- Address parsed via TONAPI: bounceable `EQC13ey5YsjSTFhuB3LpEfzXbo0JPMEgyhzNVQSW7fjC1elW`, raw `0:B5DDECB962C8D24C586E0772E911FCD76E8D093CC120CA1CCD550496EDF8C2D5`.
- On 2026-04-15 between 11:48 and 17:20 UTC the wallet sent 8 deploy transactions (2 TON each) followed by 8 funding transactions (200–202 TON each) to distinct masterchain addresses, each of which then deployed a validator wallet.
- Diagnostic query (Dune 7390293) confirms all 8 validators share this address as `inviter_of_inviter`.

## Test plan

- [ ] Maintainer review of address attribution
- [ ] After merge + next ton-labels → Dune sync, validators show under `ton_ecosystem_reserve` in Dune query 5838075