### PR TITLE
fund/telegram: add operations deployer wallet

### DIFF
--- a/assets/fund/telegram.json
+++ b/assets/fund/telegram.json
@@ -23,6 +23,14 @@
             "tags": [],
             "submittedBy": "ohld",
             "submissionTimestamp": "2025-02-04T00:00:01Z"
+        },
+        {
+            "address": "EQCZ3CmthhVRIciwzpt1VC0XFPBrP6QvVHLZe_Ydx46QSCxR",
+            "source": "tonviewer",
+            "comment": "Telegram operations deployer/funder wallet; deploys and funds vesting and validator wallets",
+            "tags": [],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2026-04-30T00:00:00Z"
         }
     ]
 }


### PR DESCRIPTION
Adds a Telegram operations deployer/funder wallet used to deploy and fund TON-related wallets, including vesting and validator wallets.\n\nAddress added under the existing Telegram fund label:\n- EQCZ3CmthhVRIciwzpt1VC0XFPBrP6QvVHLZe_Ydx46QSCxR\n\nValidation:\n- python3 build_assets.py