### PR TITLE
add new gift_satellite

### DIFF
--- a/assets/merchant/gift_satellite.json
+++ b/assets/merchant/gift_satellite.json
@@ -18,6 +18,14 @@
             ],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-08-31T17:00:02Z"
+        },
+        {
+            "address": "EQBOasBgCbNBwBZKTzlG1to0r6K4WVR6kj99mGP26tqoJ25w",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-05-13T17:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX:
0:4e6ac06009b341c0164a4f3946d6da34afa2b859547a923f7d9863f6eadaa827
Bounceable: EQBOasBgCbNBwBZKTzlG1to0r6K4WVR6kj99mGP26tqoJ25w
Non-bounceable: UQBOasBgCbNBwBZKTzlG1to0r6K4WVR6kj99mGP26tqoJzO1

<img width="1606" height="437" alt="image" src="https://github.com/user-attachments/assets/bab220fd-e11e-49ff-b5de-7bc0c9518ef5" />

This address owns the @giftsatellite Telegram collectible username which is connected to the project's Telegram channel:
<img width="1612" height="507" alt="image" src="https://github.com/user-attachments/assets/0f582dfb-e74e-47f4-b995-aea1f2698221" />

The address also immediately transfers the proceeds of Telegram Stars cashout to the gift_satellite address:
<img width="1437" height="578" alt="image" src="https://github.com/user-attachments/assets/7a80d2d0-6d98-4044-a025-f9556379eb6f" />

The channels posts receives large Stars reactions hence the Stars cashout via channel:
<img width="538" height="561" alt="image" src="https://github.com/user-attachments/assets/3bd77293-c9a9-4c77-af9f-f3b971d7ad72" />
