### PR TITLE
add new starsgram

### DIFF
--- a/assets/gaming/wingift.json
+++ b/assets/gaming/wingift.json
@@ -16,14 +16,6 @@
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-12-22T00:00:02Z"
-        },
-        {
-            "address": "EQBdDTvA95aDxRnrBY0MCnbY9H9MYJvV40PhEfNbqofdVRxq",
-            "source": "",
-            "comment": "",
-            "tags": [],
-            "submittedBy": "ef-code",
-            "submissionTimestamp": "2026-05-28T00:00:02Z"
         }
     ]
 }

--- a/assets/gaming/wingift.json
+++ b/assets/gaming/wingift.json
@@ -16,6 +16,14 @@
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-12-22T00:00:02Z"
+        },
+        {
+            "address": "EQBdDTvA95aDxRnrBY0MCnbY9H9MYJvV40PhEfNbqofdVRxq",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-05-28T00:00:02Z"
         }
     ]
 }

--- a/assets/merchant/starsgram.json
+++ b/assets/merchant/starsgram.json
@@ -32,6 +32,14 @@
             "tags": [],
             "submittedBy": "ef-code",
             "submissionTimestamp": "2025-09-13T17:00:02Z"
+        },
+        {
+            "address": "EQBdDTvA95aDxRnrBY0MCnbY9H9MYJvV40PhEfNbqofdVRxq",
+            "source": "",
+            "comment": "",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-05-28T00:00:02Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:5d0d3bc0f79683c519eb058d0c0a76d8f47f4c609bd5e343e111f35baa87dd55
Bounceable: EQBdDTvA95aDxRnrBY0MCnbY9H9MYJvV40PhEfNbqofdVRxq
Non-bounceable: UQBdDTvA95aDxRnrBY0MCnbY9H9MYJvV40PhEfNbqofdVUGv

<img width="1613" height="445" alt="image" src="https://github.com/user-attachments/assets/a501b262-0a02-40e9-bd2b-bd5d69e9306a" />

This address has received majority of inflows from Mexc and an address labelled as starsgram (UQDvWbUQQZHKzXJrt4_AO03c38any9zoQRCyJrTQ2fCuTxkc):
<img width="1312" height="474" alt="image" src="https://github.com/user-attachments/assets/eab145c0-8ba8-4b3f-8669-46d939d9fc80" />

This starsgram address appears to be the project's hot wallet used for routing funds for user related activities:
<img width="1215" height="919" alt="image" src="https://github.com/user-attachments/assets/9c709854-3849-4665-a8ff-01ceebb941cd" />

The counterparties involved in transactions with this address is further proof:
<img width="629" height="527" alt="image" src="https://github.com/user-attachments/assets/2673673d-22e6-417a-88e6-7d9ab68144cf" />


These inflows are then used to purchase stars from Fragment for users. 

Despite UQDvWbUQQZHKzXJrt4_AO03c38any9zoQRCyJrTQ2fCuTxkc association with wingift, this address is labelled under starsgram because it's main service is the sale of Telegram Stars unlike wingift:
<img width="461" height="508" alt="image" src="https://github.com/user-attachments/assets/895ba746-6b9f-47c0-8308-92a9ff50800b" />
