### PR TITLE
Add Wallet in Telegram sweep collector

### DIFF
--- a/assets/cex/wallet_in_telegram.json
+++ b/assets/cex/wallet_in_telegram.json
@@ -342,7 +342,7 @@
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2026-03-03T00:00:01Z"
         },
-    {
+        {
             "address": "EQCkoRp4OE-SFUoMEnYfL3vF43T3AzNfW8jyTC4yzk8cJqMS",
             "source": "",
             "comment": "",
@@ -351,6 +351,16 @@
             ],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2026-05-13T00:00:01Z"
+        },
+        {
+            "address": "EQAkcigwkjX7Hgshhe205vVMvHgWXz-muo34UgMo2xuptPhm",
+            "source": "Mass custodial wallet sweep to this address on 2026-05-28: 2.06M child wallets sent TON to [0:2472...A9B4](https://tonviewer.com/0:247228309235FB1E0B2185EDB4E6F54CBC78165F3FA6BA8DF8520328DB1BA9B4); Dune evidence: [collector origin labels](https://dune.com/queries/7614373), [collector metadata](https://dune.com/queries/7614383).",
+            "comment": "TON collection wallet for Wallet in Telegram custodial wallet sweeps",
+            "tags": [
+                "has-custodial-wallets"
+            ],
+            "submittedBy": "ohld",
+            "submissionTimestamp": "2026-05-30T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
Adds the Wallet in Telegram TON sweep collector:

`EQAkcigwkjX7Hgshhe205vVMvHgWXz-muo34UgMo2xuptPhm`

Raw address:

`0:247228309235FB1E0B2185EDB4E6F54CBC78165F3FA6BA8DF8520328DB1BA9B4`

Why:

- On 2026-05-28 this address received TON from about 2.06M custodial child wallets.
- User confirmation: this is Wallet in Telegram collecting remaining TON balances from custodial wallets.
- It needs the `has-custodial-wallets` tag so `dune.ton_foundation.result_custodial_wallets` can classify those child wallets back as `wallet_in_telegram`.

Evidence:

- Collector origin labels: https://dune.com/queries/7614373
- Collector metadata/funder: https://dune.com/queries/7614383
- Direct example via TONAPI: swept child wallets had prior funding from existing `wallet_in_telegram` labeled address `0:1F5806C09A28B0F01BA5D8448ED2D3FBFE7945554001BE0A7B6A0BF90054515D`.

Validation:

- `python3 build_assets.py`
