### PR TITLE
add new starsly

### DIFF
--- a/assets/merchant/starsly.json
+++ b/assets/merchant/starsly.json
@@ -2,7 +2,7 @@
     "metadata": {
         "label": "starsly",
         "name": "Starsly",
-        "organization": "starsly",
+        "organization": "laba",
         "category": "merchant",
         "subcategory": "",
         "description": "TG Stars marketplace",

--- a/assets/merchant/starsly.json
+++ b/assets/merchant/starsly.json
@@ -16,6 +16,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-12-10T17:00:02Z"
+        },
+        {
+            "address": "EQAbnn45XdUsNMqACY76faV8h5TAn-6JyMXi8ao8UpIWLQvj",
+            "source": "",
+            "comment": "Also funded by https://t.me/stars_mint_bot",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-06-05T00:00:01Z"
         }
     
     ]


### PR DESCRIPTION
HEX: 0:1b9e7e395dd52c34ca80098efa7da57c8794c09fee89c8c5e2f1aa3c5292162d
Bounceable: 	EQAbnn45XdUsNMqACY76faV8h5TAn-6JyMXi8ao8UpIWLQvj
Non-bounceable: UQAbnn45XdUsNMqACY76faV8h5TAn-6JyMXi8ao8UpIWLVYm

<img width="1623" height="430" alt="Screenshot From 2026-06-05 09-48-01" src="https://github.com/user-attachments/assets/57990c69-b215-4446-b868-ad588df3bed1" />

This address is funded through a labelled Starsly address:
<img width="1280" height="891" alt="image" src="https://github.com/user-attachments/assets/6a084401-3e53-4bd1-9228-cb05f783e5c8" />

And is also funded by a labelled stars_mint address:
<img width="1280" height="891" alt="Screenshot From 2026-06-05 10-00-36" src="https://github.com/user-attachments/assets/be5ad8bf-d3c5-465c-9de6-fc5c88a15bc7" />


It is labelled under starsly because it is mainly used for stars purchase which is the main utility of the starsly bot unlike stars_mint #886 for reference:
<img width="1280" height="891" alt="image" src="https://github.com/user-attachments/assets/5020fce1-13d3-44be-9843-b76f269802f1" />
