### PR TITLE
Add GemStar official wallet label

### DIFF
--- a/assets/merchant/gemstar_order.json
+++ b/assets/merchant/gemstar_order.json
@@ -1,0 +1,18 @@
+{
+  "label": "GemStar",
+  "name": "GemStar",
+  "category": "merchant",
+  "subcategory": "offchain_marketplace",
+  "organization": "gemstar",
+  "description": "Telegram marketplace for Telegram Stars, Telegram Gifts and Telegram Premium.",
+  "website": "https://t.me/GemStarBot",
+  "address": "0:70841b309270aa099945f9400e1b0226b935c8d149adbcb2f29a4538a920d34e",
+  "address_uf": "EQBwhBswknCqCZlF-UAOGwImuTXI0UmtvLLymkU4qSDTTgFU",
+  "address_uf_nb": "UQBwhBswknCqCZlF-UAOGwImuTXI0UmtvLLymkU4qSDTTlyR",
+  "source": "",
+  "comment": "Official GemStar order fulfillment wallet.",
+  "tags": [
+    "telegram-stars",
+    "telegram-gifts"
+  ]
+}


### PR DESCRIPTION
This pull request adds the official GemStar wallet label.

GemStar is a Telegram marketplace for Telegram Stars, Telegram Gifts and Telegram Premium.

Wallet ownership can be verified through the official Telegram bot:

https://t.me/GemStarBot

Run the following command:

/wallets

The bot lists the official GemStar wallets used by the service.