### PR TITLE
add new affluent

### DIFF
--- a/assets/lending/affluent.json
+++ b/assets/lending/affluent.json
@@ -172,6 +172,14 @@
             ],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2025-11-28T00:00:01Z"
+        },
+        {
+            "address": "EQD5O4qzJmVwuKDIfDcuM6HI7fUf1AOolgF2oiPGyqr_WZsp",
+            "source": "",
+            "comment": "Sentora Vault for Wallet",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-06-30T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:f93b8ab3266570b8a0c87c372e33a1c8edf51fd403a8960176a223c6caaaff59
Bounceable: EQD5O4qzJmVwuKDIfDcuM6HI7fUf1AOolgF2oiPGyqr_WZsp

<img width="1629" height="451" alt="image" src="https://github.com/user-attachments/assets/ed59ab38-c537-47a0-b121-a33e4273b2aa" />

This address appears to be a contract for the Affluent/Sentora USDT Vault for Wallet In Telegram. It has also been verified by Tonviewer/Tonkeeper:
<img width="1212" height="212" alt="image" src="https://github.com/user-attachments/assets/5c082648-1385-4ac7-a224-0586c9559b57" />

It was previously announced in a [post](https://t.me/tonwallet_news_en/134) on the Wallet Defi channel in April:
<img width="561" height="973" alt="image" src="https://github.com/user-attachments/assets/91356fee-70b9-4267-9c01-31e4a56d3f29" />

The metadata is also hosted by Affluent as shown in Tonviewer:
<img width="595" height="458" alt="image" src="https://github.com/user-attachments/assets/4fda56dd-405f-4cc7-8374-75ae786e9345" />

 