### PR TITLE
add new duckmyduck

### DIFF
--- a/assets/gaming/duckmyduck.json
+++ b/assets/gaming/duckmyduck.json
@@ -39,6 +39,14 @@
             "tags": [],
             "submittedBy": "Lucky0041",
             "submissionTimestamp": "2026-06-08T00:00:01Z"
+        },
+        {
+            "address": "EQDFkZEIXRVbd7DzHdHzLPnP1YiyXn-mjyJ2LSc_Zf5q736e",
+            "source": "",
+            "comment": "Telegram Stars cashout address.",
+            "tags": [],
+            "submittedBy": "ef-code",
+            "submissionTimestamp": "2026-07-01T00:00:01Z"
         }
     ]
 }


### PR DESCRIPTION
HEX: 0:c59191085d155b77b0f31dd1f32cf9cfd588b25e7fa68f22762d273f65fe6aef
Bounceable: EQDFkZEIXRVbd7DzHdHzLPnP1YiyXn-mjyJ2LSc_Zf5q736e
Non-bounceable: UQDFkZEIXRVbd7DzHdHzLPnP1YiyXn-mjyJ2LSc_Zf5q7yNb

<img width="806" height="450" alt="image" src="https://github.com/user-attachments/assets/dc33c4de-4f06-4b1f-9826-4b50709277aa" />

This address received Telegram Stars cashout proceeds and  deposited the entirety of it to a labelled duckmyduck address UQA5QCbm10EAVJmmDGxQFbwdEvbGAYHEHPrHfA3THfYveKD7:
<img width="1204" height="678" alt="Screenshot From 2026-07-01 20-30-59" src="https://github.com/user-attachments/assets/d44ad892-ee9b-45ce-9032-67c8fb3e6213" />

UQA5QC....veKD7 has previously received large GRAM (TON) deposits from labelled duckmyduck addresses:
<img width="1207" height="288" alt="image" src="https://github.com/user-attachments/assets/75e50507-6a24-43b6-bf66-b1733e0eda5e" />

The large GRAM (TON) withdrawals from UQA5QC....veKD7 to multiple addresses is instantly noticeable:
<img width="1177" height="825" alt="image" src="https://github.com/user-attachments/assets/4176dc7d-f0b7-4328-bfd2-6b27f8216b68" />

Checking out any of these withdrawals, we can see the recipients are exchange deposit addresses:
<img width="1177" height="825" alt="image" src="https://github.com/user-attachments/assets/7efc577e-e5f2-49b3-9f57-d18e93bd57ce" />

Some deposit addresses have also been used by other labelled duckmyduck addresses:
<img width="1177" height="825" alt="image" src="https://github.com/user-attachments/assets/3913ef2f-875e-48ea-a542-fa3ed0c5c9ac" />





